### PR TITLE
Story 2.4: ETF Import — Parse, Convert & Write to Isolated Catalog

### DIFF
--- a/_bmad-output/implementation-artifacts/2-4-etf-import-parse-convert-and-write-to-isolated-catalog.md
+++ b/_bmad-output/implementation-artifacts/2-4-etf-import-parse-convert-and-write-to-isolated-catalog.md
@@ -1,0 +1,220 @@
+# Story 2.4: ETF Import — Parse, Convert & Write to Isolated Catalog
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the operator,
+I want to trigger an ETF import for a source directory that parses the bars, resolves instrument metadata, and writes Nautilus-compatible Parquet to the isolated catalog at all 5 timeframes,
+so that the ETF bars land in the catalog alongside Stocks with their metadata resolved cache-first.
+
+## Acceptance Criteria
+
+1. **AC1 — Parse the 6-column schema and write Parquet to the isolated catalog.**
+   Given the ETF source directory and isolated catalog path configured via `FirstRateSettings` /
+   `CatalogSettings`, When the operator runs the ETF import CLI, Then the pipeline extracts each archive
+   (Story 2.2 `zip_extractor`), parses the 6-column headerless schema with the reused `FirstRateCsvParser`,
+   and writes bars as Parquet under `FIRSTRATE_CATALOG_PATH` following `{INSTRUMENT_ID}/{BAR_TYPE}/*.parquet`
+   (Nautilus leaf path `data/bar/{BAR_TYPE}/part-*.parquet`, where `BAR_TYPE` begins with the instrument id).
+
+2. **AC2 — All 5 native timeframes import with no restriction.**
+   Given the 5 native timeframes are present in the source, When the ETF import runs with no `--timeframe`
+   restriction, Then all five (1min, 5min, 30min, 1hour, 1day) are imported.
+
+3. **AC3 — `--timeframe` selects a subset.**
+   Given the `--timeframe` selection option, When the operator specifies one or several timeframes
+   (including `30min`), Then only the selected timeframe(s) are imported.
+
+4. **AC4 — Cache-first metadata resolution per ticker.**
+   Given each parsed ticker, When it is processed, Then `InstrumentMetadataService.resolve(ticker)` (Epic 1)
+   is invoked and the resolved metadata is upserted into `instrument_metadata` (cache-first; no redundant FMP
+   call when already `RESOLVED`). A metadata-resolution fault must not fail an otherwise-good bar import, and
+   a `skipped` (already-complete) ticker triggers no resolution call.
+
+5. **AC5 — Isolation + fidelity.**
+   Given the isolated-catalog rule, When ETF Parquet is written, Then it is written only under the FirstRate
+   catalog path (never mixed with IBKR/Kraken data), and decimal precision + UTC-normalized timestamps are
+   preserved on round-trip (Phase 1 discipline).
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Wire `InstrumentMetadataService.resolve()` into the import loop (AC: #4)**
+  - [x] Add an optional `metadata_resolver: InstrumentMetadataService | None = None` constructor dependency
+        to `ImportService` (default `None` keeps the Phase-1 stocks path and all existing tests valid).
+  - [x] In `_import_ticker`, after a successful parse (non-empty bars) and before the catalog write, call a
+        new `_resolve_metadata(ticker)` helper that invokes `self._metadata_resolver.resolve(ticker)` only
+        when a resolver is injected. Wrap the call in its own `try/except` so a metadata fault is logged and
+        isolated — it never flips a good bar import to `failed` (the single `resolve()` does not isolate like
+        `resolve_batch`). Placed after the `skipped` short-circuit so already-complete tickers never resolve.
+
+- [x] **Task 2 — CLI timeframe surface: 30min + all-5 ETF default (AC: #2, #3)**
+  - [x] Add `"30min": "30-MINUTE-LAST"` to `TIMEFRAME_MAP` in `src/cli/commands/import_data.py`
+        (sourced from `ExplorerTimeframe.THIRTY_MIN.bar_type_spec`, the central enum).
+  - [x] When the import path receives no `--timeframe` AND the asset class is ETF, default to all five native
+        timeframes (1min, 5min, 30min, 1hour, 1day). The stocks path keeps its `daily` default and the
+        dry-run path is unchanged.
+
+- [x] **Task 3 — CLI wires the metadata resolver (AC: #4)**
+  - [x] In `_run_import`, for the ETF path, construct an `InstrumentMetadataService` from the FMP provider
+        (`FMPMetadataProvider` + `FMPClient`) and a `SyncInstrumentMetadataRepository` over the existing sync
+        session, and pass it to `ImportService`. If FMP is unconfigured (no API key), warn and proceed with
+        `metadata_resolver=None` (graceful offline degradation) — bars still import. Never make a network call
+        at construction time.
+
+- [x] **Task 4 — Tests with real temp fixtures + fakes (AC: #1, #2, #3, #4, #5)**
+  - [x] Component (`tests/component/services/firstrate/test_import_service.py`): a real `FirstRateCsvParser`
+        + real `CatalogManager` over a temp `FIRSTRATE_CATALOG_PATH`; import ≥2 ETF tickers and assert the
+        on-disk `data/bar/{BAR_TYPE}/part-*.parquet` leaf layout (BAR_TYPE starts with the instrument id),
+        round-trip OHLCV decimal precision + UTC `ts_init` fidelity, and that nothing is written outside the
+        FirstRate catalog dir (AC1, AC5).
+  - [x] Component: a fake/in-memory `InstrumentMetadataService` (real service + fake provider + in-memory
+        store) — assert `resolve()` is called once per parsed ticker; a pre-seeded `RESOLVED` row is a cache
+        hit (provider NOT called); an unseeded ticker hits the provider once and upserts; `skipped` tickers
+        trigger no resolve; a resolver exception leaves the bar import `success` (AC4).
+  - [x] Unit (`tests/unit/cli/commands/test_import_data.py`): `parse_timeframes("30min") == ["30-MINUTE-LAST"]`;
+        the ETF no-`--timeframe` default expands to all five specs; the stocks default stays `["1-DAY-LAST"]`
+        (AC2, AC3).
+
+- [x] **Task 5 — Gates**
+  - [x] `uv run ruff check .` clean; `uv run mypy .` clean (no NEW errors vs the documented baseline);
+        `make test-unit` + `make test-component` green for the touched areas.
+
+## Dev Notes
+
+### Build ON the existing pipeline — do NOT rewrite it
+The per-ticker import loop already parses → writes Parquet → verifies row count → verifies sample points →
+upserts catalog-instrument metadata, with per-ticker error isolation and a Story-1-7 idempotent classifier:
+- `src/services/firstrate/import_service.py` — `ImportService.import_directory` / `_import_ticker`. AC1/AC5's
+  parse + isolated-catalog write + decimal/UTC fidelity are already implemented here (the parser normalizes ET→UTC
+  and parses prices/volume through `Decimal`/`Price`/`Quantity`); this story **adds** the Epic-1 metadata-resolve
+  call into that loop and proves the catalog-write ACs with a real round-trip test.
+- `src/services/firstrate/parsers/firstrate_csv_parser.py` — the reused 6-column headerless parser (ETF + STOCK).
+- `src/services/firstrate/catalog_manager.py` — resolves the named FirstRate catalog to a `ParquetDataCatalog`.
+- `src/services/firstrate/zip_extractor.py` — Story 2.2 per-archive extraction (the documented extraction stage
+  that yields the `.txt` files the import loop consumes; its handler-seam stays as-is).
+- `src/services/metadata/instrument_metadata_service.py` — Epic 1 `resolve(ticker)`: cache-first, only a
+  `RESOLVED` row short-circuits the provider; it owns the upsert into `instrument_metadata`.
+
+### The metadata-resolve wiring (AC4)
+`InstrumentMetadataService.resolve` is cache-first and self-upserting (`instrument_metadata_service.py:48-62`),
+so the import loop only needs to **call** `resolve(ticker)` per parsed ticker — no separate upsert. Inject it
+as an optional dependency (mirrors how `catalog_manager` / `metadata_service` / `instrument_mapper` are injected)
+so the stocks path and existing tests — which pass no resolver — are unaffected. Isolate the call in its own
+`try/except`: a single `resolve()` (unlike `resolve_batch`) does not swallow provider faults, and a metadata
+hiccup must never fail a verified bar import. Place it after the `skipped` short-circuit so an already-complete
+re-run makes no resolve call (sets up Story 2.6's "no FMP calls when nothing changed").
+
+### Catalog layout & the test tier constraint
+Nautilus writes bars to `data/bar/{BAR_TYPE}/part-*.parquet`, where `BAR_TYPE` is
+`{INSTRUMENT_ID}-{step}-{agg}-{price}-EXTERNAL` (e.g. `SPY.ARCA-1-MINUTE-LAST-EXTERNAL`) — so the
+`{INSTRUMENT_ID}/{BAR_TYPE}` layout in the AC is encoded in the leaf dir name. Real `ParquetDataCatalog`
+write/read is exercised in a **component** test over a `tmp_path` catalog (no `BacktestEngine`, so no
+`--forked` engine-state hazard); the assertion walks the catalog dir for the `bar` leaf and reads bars back to
+check decimal precision + UTC `ts_init`. If a bare catalog write proves unsafe without `--forked` in this repo,
+fall back to asserting the production `catalog.write_data(bars)` call carries bars whose `bar_type` stringifies
+to the expected `{INSTRUMENT_ID}-{BAR_TYPE}` and keep the on-disk-layout assertion in an `--forked` integration
+test — but prefer the real component round-trip per the TEA guidance.
+
+### CLI timeframe surface (AC2/AC3)
+`TIMEFRAME_MAP` is missing `30min` (Story 2.1 added the 30-minute convention via `ExplorerTimeframe.THIRTY_MIN`).
+Add it. For the ETF import path with no `--timeframe`, default to all five native specs so AC2 holds; keep the
+stocks default at `daily` and leave the dry-run path untouched (its STOCK default + `test_dry_run_never_constructs_services`
+invariant must hold). FirstRate ships one timeframe per source layout, so the per-timeframe loop in `_run_import`
+already drives the selection — this story only widens the default + adds the `30min` token.
+
+### Out of scope (later stories / epics — do NOT implement)
+- Verification surfacing in the summary beyond what exists (Story 2.5), date-range idempotency tuning (Story 2.6),
+  and `ResolutionSummary` in the summary (Story 2.7).
+- Venue resolution / Nautilus-qualified InstrumentId (Epic 3), explorer ETF work (Epic 4), backtests (Epic 5).
+- Any DB schema change or Alembic migration — **this story needs none** (`instrument_metadata` exists from Epic 1).
+- Any change to financial calculations or previously produced numbers.
+
+### Project Structure Notes
+- **Modified:** `src/services/firstrate/import_service.py` (optional resolver dep + `_resolve_metadata`),
+  `src/cli/commands/import_data.py` (TIMEFRAME_MAP `30min`, ETF all-5 default, resolver wiring). Stay under size
+  limits (files <500 lines, functions <50, classes <100, line <100).
+- **Modified tests:** `tests/component/services/firstrate/test_import_service.py`,
+  `tests/unit/cli/commands/test_import_data.py`.
+- No new dependency, no migration, no Nautilus import added to a pure module.
+
+### Testing standards
+- **TDD** (CLAUDE.md / development-principles): failing test first (Red-Green-Refactor).
+- **Tiers:** Component for the full import loop with the real parser/catalog + fakes; Unit for the CLI timeframe
+  parsing/default math. No engine, no Postgres, no network. Commands: `make test-unit`, `make test-component`.
+- **Real fixtures:** temp `.txt` trees in `tmp_path`; a temp FirstRate catalog dir; a fake `MetadataProvider`
+  (counts calls, never network) behind a real `InstrumentMetadataService` over an in-memory store.
+- **Import gate (F401/F821):** add imports and usages in the same edit.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-2.4] — parse 6-col schema, write isolated Parquet at
+  all 5 timeframes, `--timeframe` subset, cache-first `InstrumentMetadataService.resolve`, isolation + fidelity (lines 479-505)
+- [Source: harness-epic2-rest-spec.md#Story-2.4] — scoped ACs + TEA verification guidance (temp catalog layout,
+  row fidelity, resolve cache-first with fake store, no network/DB/real import)
+- [Source: src/services/firstrate/import_service.py] — existing parse→write→verify→upsert loop + idempotent classifier to extend
+- [Source: src/services/metadata/instrument_metadata_service.py:48-62] — cache-first `resolve`: only RESOLVED short-circuits the provider; self-upserts
+- [Source: src/services/metadata/providers/base.py] — `MetadataProvider` Protocol the fake provider satisfies structurally
+- [Source: src/api/models/explorer.py:18-30] — `ExplorerTimeframe` central enum (30-MINUTE-LAST bar_type_spec)
+- [Source: tests/component/api/test_chart_panel_routes.py:294] — catalog leaf path `…-1-DAY-LAST-EXTERNAL/part-0.parquet`
+- [Source: _bmad-output/implementation-artifacts/2-2-per-archive-zip-extraction.md] — injected-seam precedent (extractor handler)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8
+
+### Debug Log References
+
+### Completion Notes List
+
+- **AC4 wiring:** `ImportService` gained an optional `metadata_resolver`
+  (`InstrumentMetadataService | None`, default `None` → Phase-1 stocks path and
+  all existing call sites unchanged). `_resolve_metadata(ticker)` is invoked in
+  `_import_ticker` after a successful parse and after the `skipped` short-circuit,
+  fault-isolated in its own `try/except` so a metadata hiccup never fails a
+  verified bar import. The Epic-1 service owns cache-first + upsert.
+- **AC2/AC3:** `30min` added to `TIMEFRAME_MAP` (sourced from
+  `ExplorerTimeframe.THIRTY_MIN.bar_type_spec` to honor the Story-2.1 single-literal
+  guard); `resolve_timeframes()` defaults the ETF path to all five native
+  timeframes and lets an explicit `--timeframe` win. `_build_metadata_resolver()`
+  wires the FMP-backed resolver for ETF only, degrading to `None` (with a warning)
+  when FMP is unconfigured — no network at construction (lazy httpx client).
+- **AC1/AC5:** proven by a real `FirstRateCsvParser` + real `ParquetDataCatalog`
+  round-trip in a component test (no engine, so no `--forked` needed): on-disk
+  `data/bar/{BAR_TYPE}/*.parquet` leaf layout, decimal precision + ET→UTC fidelity,
+  and catalog isolation (only the `firstrate-etf` dir is written).
+- **Code-review fixes (parallel Blind Hunter / Edge Case Hunter / Acceptance
+  Auditor):**
+  - *Timeframe-blind discovery (Edge #1, High):* the new all-5 default would have
+    re-parsed every file under all 5 bar types because `_discover_tickers` ignored
+    the timeframe. Added an optional timeframe filter that reuses the dry-run's
+    `_infer_timeframe`; files with no recognizable timeframe token stay
+    timeframe-agnostic (backward-compatible with the Phase-1 per-dir layout and
+    untokenized test fixtures). `timeframe=None` disables filtering.
+  - *Resolve multiplication (Blind #1 / Edge #3, Medium):* added an instance-level
+    `_resolved_tickers` set so resolution runs at-most-once per ticker per run; the
+    multi-timeframe ETF default no longer re-hits the provider for not-yet-RESOLVED
+    tickers on each pass.
+  - *Accepted (out of scope this story):* the resolver upserts via `flush` and
+    commits with the whole batch at the end of `_run_import` — a fatal error rolls
+    everything back, identical to the existing catalog-instrument upsert path. A
+    per-ticker transactional boundary is a larger change deferred to later stories;
+    rolled-back tickers are simply re-resolved cache-first on the next run.
+- **Gates:** `ruff check .` clean; `mypy .` "Success: no issues found in 338
+  source files"; `make test-unit` and `make test-component` green.
+
+### File List
+
+- `src/services/firstrate/import_service.py` (optional `metadata_resolver` +
+  `_resolve_metadata` with per-run dedup; timeframe-filtered `_discover_tickers` +
+  `_matches_timeframe`)
+- `src/cli/commands/import_data.py` (`30min` token via `ExplorerTimeframe`,
+  `ETF_DEFAULT_TIMEFRAMES`, `resolve_timeframes`, `_build_metadata_resolver`,
+  resolver wired into `_run_import`)
+- `tests/unit/services/firstrate/test_import_service.py` (timeframe-filter discovery tests)
+- `tests/unit/cli/commands/test_import_data.py` (`30min` token, `TestResolveTimeframes`, `TestBuildMetadataResolver`)
+- `tests/component/services/firstrate/test_import_service.py` (`TestEtfCatalogRoundTrip`, `TestMetadataResolveWiring` incl. per-run dedup)
+- `_bmad-output/implementation-artifacts/2-4-etf-import-parse-convert-and-write-to-isolated-catalog.md` (this story)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -64,7 +64,7 @@ development_status:
   2-1-30-minute-timeframe-convention-expansion: done
   2-2-per-archive-zip-extraction: done
   2-3-dry-run-scan-with-fmp-aware-estimate: done
-  2-4-etf-import-parse-convert-and-write-to-isolated-catalog: backlog
+  2-4-etf-import-parse-convert-and-write-to-isolated-catalog: done
   2-5-import-verification-ohlc-sanity-row-count-parity-and-sample-point: backlog
   2-6-idempotent-re-runs-via-date-range-comparison: backlog
   2-7-import-summary-and-progress-reporting: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -63,7 +63,7 @@ development_status:
   epic-2: in-progress
   2-1-30-minute-timeframe-convention-expansion: done
   2-2-per-archive-zip-extraction: done
-  2-3-dry-run-scan-with-fmp-aware-estimate: in-progress
+  2-3-dry-run-scan-with-fmp-aware-estimate: done
   2-4-etf-import-parse-convert-and-write-to-isolated-catalog: backlog
   2-5-import-verification-ohlc-sanity-row-count-parity-and-sample-point: backlog
   2-6-idempotent-re-runs-via-date-range-comparison: backlog

--- a/src/cli/commands/import_data.py
+++ b/src/cli/commands/import_data.py
@@ -2,12 +2,21 @@
 
 from collections.abc import Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.console import Console
 from rich.table import Table
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
+
+from src.api.models.explorer import ExplorerTimeframe
+
+if TYPE_CHECKING:
+    from src.config import FMPSettings
+    from src.services.metadata.instrument_metadata_service import (
+        InstrumentMetadataService,
+    )
 
 from src.cli.commands.import_reporting import (
     _print_progress_line,
@@ -36,7 +45,13 @@ TIMEFRAME_MAP = {
     "minute": "1-MINUTE-LAST",
     "1min": "1-MINUTE-LAST",
     "5min": "5-MINUTE-LAST",
+    # 30min bar-type literal lives only in the central enum (Story 2.1 guard).
+    "30min": ExplorerTimeframe.THIRTY_MIN.bar_type_spec,
 }
+
+#: The five native FirstRate timeframes imported when the ETF path is given no
+#: ``--timeframe`` restriction (Story 2.4 AC2). Ordered coarse→fine.
+ETF_DEFAULT_TIMEFRAMES = "daily,hourly,30min,5min,1min"
 
 ASSET_CLASS_MAP = {
     "etf": AssetClass.ETF,
@@ -96,6 +111,48 @@ def _open_metadata_session() -> Session | None:
     return session_maker()
 
 
+def _build_metadata_resolver(
+    session: Session,
+    asset_class: AssetClass,
+    fmp_settings: "FMPSettings",
+) -> "InstrumentMetadataService | None":
+    """Build the Epic-1 cache-first metadata resolver for the ETF import path.
+
+    Returns ``None`` (no resolution) when the asset class is not ETF or when FMP
+    is unconfigured (empty ``fmp_api_key``), so a missing key degrades the import
+    gracefully — bars still import, only metadata resolution is skipped (with a
+    warning). Construction is side-effect-free: ``FMPClient`` builds its httpx
+    client lazily, so no network call happens here.
+
+    Args:
+        session: Open sync DB session backing the metadata cache repository.
+        asset_class: Resolved asset class for the import run.
+        fmp_settings: FMP provider settings (provides ``fmp_api_key``).
+
+    Returns:
+        A wired ``InstrumentMetadataService``, or ``None`` to skip resolution.
+    """
+    if asset_class != AssetClass.ETF:
+        return None
+    if not fmp_settings.fmp_api_key:
+        console.print(
+            "[yellow]FMP not configured (FMP_API_KEY empty) — instrument metadata "
+            "resolution skipped; bars will still import.[/yellow]"
+        )
+        return None
+
+    from src.db.repositories.instrument_metadata_repository_sync import (
+        SyncInstrumentMetadataRepository,
+    )
+    from src.services.metadata.fmp_client import FMPClient
+    from src.services.metadata.instrument_metadata_service import InstrumentMetadataService
+    from src.services.metadata.providers.fmp_provider import FMPMetadataProvider
+
+    provider = FMPMetadataProvider(FMPClient(fmp_settings))
+    repository = SyncInstrumentMetadataRepository(session)
+    return InstrumentMetadataService(provider=provider, repository=repository)
+
+
 def _find_profiles_csv(source_path: Path) -> Path | None:
     """Locate the FirstRate company_profiles.csv for a given import source.
 
@@ -142,6 +199,26 @@ def parse_timeframes(timeframe_str: str) -> list[str]:
             seen.add(spec)
             specs.append(spec)
     return specs
+
+
+def resolve_timeframes(timeframe: str | None, asset_class: AssetClass) -> list[str]:
+    """Resolve which timeframe specs an import should cover.
+
+    An explicit ``--timeframe`` always wins (Story 2.4 AC3). With no restriction,
+    the ETF path imports all five native timeframes (AC2); every other asset
+    class keeps the historical ``daily`` default.
+
+    Args:
+        timeframe: The raw ``--timeframe`` value, or ``None`` when unset.
+        asset_class: The resolved asset class for the run.
+
+    Returns:
+        Ordered list of Nautilus timeframe specs to import.
+    """
+    if timeframe:
+        return parse_timeframes(timeframe)
+    default = ETF_DEFAULT_TIMEFRAMES if asset_class == AssetClass.ETF else "daily"
+    return parse_timeframes(default)
 
 
 def _run_import(
@@ -197,8 +274,10 @@ def _run_import(
     # Parse asset class (default to ETF for FirstRate)
     ac = ASSET_CLASS_MAP.get((asset_class or "etf").lower(), AssetClass.ETF)
 
-    # Parse timeframes (default to daily)
-    timeframes = parse_timeframes(timeframe or "daily")
+    # Parse timeframes. With no --timeframe, the ETF path imports all five
+    # native timeframes (Story 2.4 AC2); other asset classes keep the daily
+    # default. An explicit --timeframe always wins (AC3).
+    timeframes = resolve_timeframes(timeframe, ac)
 
     # Wire dependencies
     session = None
@@ -217,7 +296,16 @@ def _run_import(
         sync_repo = SyncCatalogInstrumentRepository(session)
         metadata_service = MetadataService(sync_repo=sync_repo)
         instrument_mapper = InstrumentMapper(sync_repo)
-        import_service = ImportService(catalog_manager, metadata_service, instrument_mapper)
+        # Story 2.4 AC4: ETF imports resolve each parsed ticker's instrument
+        # metadata cache-first via the Epic-1 service. Built lazily (no network
+        # at construction); omitted with a warning if FMP is unconfigured.
+        metadata_resolver = _build_metadata_resolver(session, ac, settings.fmp)
+        import_service = ImportService(
+            catalog_manager,
+            metadata_service,
+            instrument_mapper,
+            metadata_resolver=metadata_resolver,
+        )
 
         # Ensure profiles are loaded
         if not instrument_mapper.is_loaded(catalog):

--- a/src/services/firstrate/import_service.py
+++ b/src/services/firstrate/import_service.py
@@ -8,17 +8,27 @@ single ticker failure does not abort the batch.
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import structlog
 from nautilus_trader.model.data import Bar, BarType
 
 from src.models.catalog import AssetClass, ImportResult
 from src.services.firstrate.catalog_manager import CatalogManager
+
+# Reuse the pure filename→timeframe inference from the dry-run scanner so the
+# import filter and the dry-run scan agree on which file belongs to which
+# timeframe (single source of truth; no third copy of the suffix map).
+from src.services.firstrate.dry_run import _UNKNOWN_TIMEFRAME, _infer_timeframe
 from src.services.firstrate.instrument_mapper import InstrumentMapper
 from src.services.firstrate.metadata_service import MetadataService
 from src.services.firstrate.parsers.base import get_parser
 from src.services.firstrate.source_probe import compute_source_last_date
+
+if TYPE_CHECKING:
+    from src.services.metadata.instrument_metadata_service import (
+        InstrumentMetadataService,
+    )
 
 logger = structlog.get_logger(__name__)
 
@@ -75,6 +85,10 @@ class ImportService:
         catalog_manager: Resolves named catalogs to ParquetDataCatalog.
         metadata_service: CRUD for catalog instrument metadata.
         instrument_mapper: Resolves tickers to Nautilus InstrumentIds.
+        metadata_resolver: Optional Epic-1 ``InstrumentMetadataService`` used to
+            resolve each parsed ticker's instrument metadata cache-first (Story
+            2.4 AC4). ``None`` (the default) disables resolution — the Phase-1
+            stocks path and existing call sites pass nothing and are unaffected.
     """
 
     def __init__(
@@ -82,10 +96,19 @@ class ImportService:
         catalog_manager: CatalogManager,
         metadata_service: MetadataService,
         instrument_mapper: InstrumentMapper,
+        metadata_resolver: "InstrumentMetadataService | None" = None,
     ) -> None:
         self._catalog_manager = catalog_manager
         self._metadata_service = metadata_service
         self._instrument_mapper = instrument_mapper
+        self._metadata_resolver = metadata_resolver
+        # Tickers whose metadata has already been resolved this instance's
+        # lifetime. The CLI reuses one ImportService across all timeframe passes,
+        # so this dedups resolution to at-most-once per ticker per run — without
+        # it, a ticker present in N timeframes (e.g. the 5-timeframe ETF default)
+        # would re-invoke resolve() N times, re-hitting the provider for every
+        # not-yet-RESOLVED ticker on each pass.
+        self._resolved_tickers: set[str] = set()
 
     def import_directory(
         self,
@@ -118,7 +141,7 @@ class ImportService:
                 "Load company profiles before importing."
             )
 
-        tickers = self._discover_tickers(source_dir)
+        tickers = self._discover_tickers(source_dir, timeframe)
         logger.info(
             "import_directory_start",
             source_dir=str(source_dir),
@@ -225,6 +248,16 @@ class ImportService:
                     error="No bars parsed from file",
                     duration=time.perf_counter() - start,
                 )
+
+            # 3b. Resolve instrument metadata (Story 2.4 AC4). Cache-first via
+            #     the Epic-1 service, which self-upserts into instrument_metadata
+            #     and skips the provider when the ticker is already RESOLVED.
+            #     Runs once per parsed ticker per run — deduped inside the helper
+            #     so the multi-timeframe ETF default does not re-resolve, and the
+            #     "skipped" short-circuit above means an already-complete re-run
+            #     resolves nothing. Faults are isolated inside the helper so a
+            #     metadata hiccup never fails an otherwise-good bar import.
+            self._resolve_metadata(ticker)
 
             # 4. Write to catalog. Delete any existing bars for this exact
             #    bar_type first so a re-import (or an orphan-heal where the
@@ -437,23 +470,53 @@ class ImportService:
             timeframe=timeframe,
         )
 
-    def _discover_tickers(self, source_dir: Path) -> list[tuple[str, Path]]:
+    def _discover_tickers(
+        self, source_dir: Path, timeframe: str | None = None
+    ) -> list[tuple[str, Path]]:
         """Traverse alphabetical subdirectories and discover ticker files.
+
+        FirstRate ETF deliveries mix timeframes in one source tree, with each
+        file's timeframe encoded in its name (``{TICKER}_full_{tf}_…``). When a
+        ``timeframe`` spec is given, only files whose inferred timeframe matches
+        it are returned, so a per-timeframe import pass never re-parses another
+        timeframe's bars under the wrong ``BarType``. Files with no recognizable
+        timeframe token in their name (e.g. plain ``SPY.txt``, or a Phase-1
+        per-timeframe-directory layout) are always included for backward
+        compatibility. ``timeframe=None`` disables filtering entirely.
 
         Args:
             source_dir: Root directory with single-letter subdirectories.
+            timeframe: Nautilus timeframe spec to filter by, or ``None`` for no
+                filtering.
 
         Returns:
-            Sorted list of (ticker, file_path) tuples from .txt files.
+            Sorted list of (ticker, file_path) tuples from matching .txt files.
         """
         tickers: list[tuple[str, Path]] = []
         for subdir in sorted(source_dir.iterdir()):
             if not subdir.is_dir():
                 continue
             for file in sorted(subdir.iterdir()):
-                if file.suffix == ".txt" and file.is_file():
+                if (
+                    file.suffix == ".txt"
+                    and file.is_file()
+                    and self._matches_timeframe(file.name, timeframe)
+                ):
                     tickers.append((self._extract_ticker(file), file))
         return tickers
+
+    @staticmethod
+    def _matches_timeframe(filename: str, timeframe: str | None) -> bool:
+        """True if ``filename`` belongs to the requested ``timeframe``.
+
+        A file matches when no timeframe filter is requested, when its name
+        carries no recognizable timeframe token (treated as timeframe-agnostic),
+        or when its inferred timeframe equals ``timeframe``.
+        """
+        if timeframe is None:
+            return True
+        inferred = _infer_timeframe(filename)
+        return inferred == _UNKNOWN_TIMEFRAME or inferred == timeframe
 
     @staticmethod
     def _extract_ticker(file: Path) -> str:
@@ -551,6 +614,34 @@ class ImportService:
             and a.close == b.close
             and a.volume == b.volume
         )
+
+    def _resolve_metadata(self, ticker: str) -> None:
+        """Resolve a parsed ticker's instrument metadata cache-first (Story 2.4).
+
+        Delegates to the injected Epic-1 :class:`InstrumentMetadataService`,
+        which is cache-first (only a ``RESOLVED`` row short-circuits the
+        provider) and self-upserts into ``instrument_metadata``. A no-op when no
+        resolver is injected (the Phase-1 stocks path).
+
+        The single ``resolve()`` does not isolate provider faults the way
+        ``resolve_batch`` does, so the call is wrapped here: a metadata-
+        resolution failure is logged and swallowed and must never flip a
+        verified bar import to ``failed``.
+
+        Args:
+            ticker: Trading symbol whose metadata should be resolved.
+        """
+        if self._metadata_resolver is None:
+            return
+        if ticker in self._resolved_tickers:
+            return
+        # Mark attempted before the call so a transient fault is not retried on
+        # every subsequent timeframe pass within the same run.
+        self._resolved_tickers.add(ticker)
+        try:
+            self._metadata_resolver.resolve(ticker)
+        except Exception as e:  # noqa: BLE001 — isolate metadata faults from bars
+            logger.warning("metadata_resolution_failed", ticker=ticker, error=str(e))
 
     def _upsert_metadata(
         self,

--- a/tests/component/services/firstrate/test_import_service.py
+++ b/tests/component/services/firstrate/test_import_service.py
@@ -621,3 +621,344 @@ class TestIdempotentRerun:
             mock_catalog_manager.resolve_catalog.return_value.write_data.call_count
             == baseline_writes + 1
         )
+
+
+# ---------------------------------------------------------------------------
+# Story 2.4 — real-catalog round-trip (parse → isolated Parquet → read back)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def etf_catalog_base(tmp_path: Path) -> Path:
+    """Temp catalog base holding a single isolated ``firstrate-etf`` catalog dir."""
+    base = tmp_path / "catalogs"
+    base.mkdir()
+    (base / "firstrate-etf").mkdir()
+    return base
+
+
+@pytest.fixture()
+def etf_intraday_source(tmp_path: Path) -> Path:
+    """Source tree with 2 ETF tickers of intraday rows carrying decimal prices."""
+    src = tmp_path / "source"
+    s_dir = src / "S"
+    s_dir.mkdir(parents=True)
+    (s_dir / "SPY.txt").write_text(
+        "2024-01-02 09:30:00,100.12,101.55,99.50,100.75,1000\n"
+        "2024-01-02 09:31:00,100.75,102.00,100.00,101.25,2000\n"
+    )
+    q_dir = src / "Q"
+    q_dir.mkdir(parents=True)
+    (q_dir / "QQQ.txt").write_text(
+        "2024-01-02 09:30:00,50.10,51.00,49.90,50.50,500\n"
+        "2024-01-02 09:31:00,50.50,52.00,50.00,51.25,750\n"
+    )
+    return src
+
+
+@pytest.mark.component
+class TestEtfCatalogRoundTrip:
+    """AC1/AC5: real parser + real ParquetDataCatalog write to the isolated catalog."""
+
+    def test_writes_isolated_parquet_with_layout_and_fidelity(
+        self,
+        etf_catalog_base,
+        etf_intraday_source,
+        mock_metadata_service,
+        mock_instrument_mapper,
+    ):
+        from datetime import datetime, timezone
+
+        from src.services.firstrate.catalog_manager import CatalogManager
+
+        catalog_manager = CatalogManager(etf_catalog_base)
+        service = ImportService(
+            catalog_manager=catalog_manager,
+            metadata_service=mock_metadata_service,
+            instrument_mapper=mock_instrument_mapper,
+        )
+
+        results = service.import_directory(
+            source_dir=etf_intraday_source,
+            catalog_name="firstrate-etf",
+            asset_class=AssetClass.ETF,
+            timeframe="1-MINUTE-LAST",
+        )
+
+        assert {r.ticker for r in results} == {"SPY", "QQQ"}
+        assert all(r.status == "success" for r in results)
+        assert all(r.row_count == 2 for r in results)
+
+        # AC1: on-disk leaf layout data/bar/{BAR_TYPE}/*.parquet where BAR_TYPE
+        # begins with the instrument id ({INSTRUMENT_ID}/{BAR_TYPE}).
+        bar_dir = etf_catalog_base / "firstrate-etf" / "data" / "bar"
+        leaf_dirs = sorted(p.name for p in bar_dir.iterdir() if p.is_dir())
+        assert leaf_dirs == [
+            "QQQ.ARCA-1-MINUTE-LAST-EXTERNAL",
+            "SPY.ARCA-1-MINUTE-LAST-EXTERNAL",
+        ]
+        for leaf in leaf_dirs:
+            assert list((bar_dir / leaf).glob("*.parquet")), f"no parquet under {leaf}"
+
+        # AC5: isolation — only the firstrate-etf catalog dir exists under base
+        # (nothing mixed with IBKR/Kraken).
+        assert sorted(p.name for p in etf_catalog_base.iterdir() if p.is_dir()) == ["firstrate-etf"]
+
+        # AC5: decimal precision + UTC normalization preserved on round-trip.
+        catalog = catalog_manager.resolve_catalog("firstrate-etf")
+        spy_bars = catalog.bars(bar_types=["SPY.ARCA-1-MINUTE-LAST-EXTERNAL"])
+        assert len(spy_bars) == 2
+        assert str(spy_bars[0].open) == "100.12"
+        assert str(spy_bars[0].high) == "101.55"
+        # 09:30 ET on 2024-01-02 (EST, UTC-5) == 14:30 UTC.
+        expected_ts = (
+            int(datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc).timestamp()) * 1_000_000_000
+        )
+        assert spy_bars[0].ts_init == expected_ts
+
+
+# ---------------------------------------------------------------------------
+# Story 2.4 — cache-first metadata resolution wiring (AC4)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMetadataProvider:
+    """In-memory ``MetadataProvider`` that counts calls and never hits a network."""
+
+    PROVIDER_NAME = "FAKE"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def resolve(self, ticker: str):
+        from src.models.instrument_metadata import (
+            AssetType,
+            InstrumentMetadata,
+            ResolutionStatus,
+        )
+
+        self.calls.append(ticker)
+        return InstrumentMetadata(
+            ticker=ticker,
+            metadata_provider=self.PROVIDER_NAME,
+            venue="ARCA",
+            currency="USD",
+            asset_type=AssetType.ETF,
+            company_name="Fake Co",
+            sector="Funds",
+            industry="ETF",
+            country="US",
+            resolution_status=ResolutionStatus.RESOLVED,
+        )
+
+
+class _FakeMetadataRepo:
+    """In-memory stand-in for ``SyncInstrumentMetadataRepository`` (no DB)."""
+
+    def __init__(self) -> None:
+        self.store: dict = {}
+
+    def get_by_ticker(self, ticker: str):
+        return self.store.get(ticker)
+
+    def upsert(self, orm):
+        self.store[orm.ticker] = orm
+        return orm
+
+
+def _resolved_orm_row(ticker: str):
+    """Build a RESOLVED ORM cache row (no session needed)."""
+    from datetime import datetime, timezone
+
+    from src.db.models.instrument_metadata import InstrumentMetadata as OrmInstrumentMetadata
+    from src.models.instrument_metadata import ResolutionStatus
+
+    return OrmInstrumentMetadata(
+        ticker=ticker,
+        metadata_provider="FAKE",
+        venue="ARCA",
+        currency="USD",
+        asset_type="ETF",
+        company_name="Seeded Co",
+        sector="Funds",
+        industry="ETF",
+        country="US",
+        resolution_status=ResolutionStatus.RESOLVED,
+        resolved_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.component
+class TestMetadataResolveWiring:
+    """AC4: each parsed ticker resolves cache-first; skips/faults behave correctly."""
+
+    def _service(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+    ):
+        return ImportService(
+            catalog_manager=mock_catalog_manager,
+            metadata_service=mock_metadata_service,
+            instrument_mapper=mock_instrument_mapper,
+            metadata_resolver=resolver,
+        )
+
+    def test_resolve_called_once_per_parsed_ticker(
+        self,
+        source_dir,
+        mock_catalog_manager,
+        mock_metadata_service,
+        mock_instrument_mapper,
+        bars_by_ticker,
+    ):
+        resolver = MagicMock()
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            service = self._service(
+                mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+            )
+            service.import_directory(
+                source_dir=source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+            )
+
+        resolved = [c.args[0] for c in resolver.resolve.call_args_list]
+        assert sorted(resolved) == ["AAPL", "ARKK", "SPY"]
+
+    def test_resolve_deduped_across_timeframe_passes(
+        self,
+        source_dir,
+        mock_catalog_manager,
+        mock_metadata_service,
+        mock_instrument_mapper,
+        bars_by_ticker,
+    ):
+        """One ImportService reused across timeframe passes resolves each ticker once.
+
+        Mirrors the CLI's per-timeframe loop over a single reused service. The
+        source files here are timeframe-agnostic, so every ticker is discovered
+        on both passes — without dedup that would be 6 resolve() calls.
+        """
+        resolver = MagicMock()
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            service = self._service(
+                mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+            )
+            for tf in ("1-DAY-LAST", "1-HOUR-LAST"):
+                service.import_directory(
+                    source_dir=source_dir,
+                    catalog_name=CATALOG_NAME,
+                    asset_class=AssetClass.ETF,
+                    timeframe=tf,
+                )
+
+        resolved = sorted(c.args[0] for c in resolver.resolve.call_args_list)
+        assert resolved == ["AAPL", "ARKK", "SPY"]  # once each, not 6 calls
+
+    def test_cache_first_resolved_ticker_skips_provider(
+        self,
+        source_dir,
+        mock_catalog_manager,
+        mock_metadata_service,
+        mock_instrument_mapper,
+        bars_by_ticker,
+    ):
+        from typing import cast
+
+        from src.db.repositories.instrument_metadata_repository_sync import (
+            SyncInstrumentMetadataRepository,
+        )
+        from src.services.metadata.instrument_metadata_service import (
+            InstrumentMetadataService,
+        )
+
+        provider = _FakeMetadataProvider()
+        repo = _FakeMetadataRepo()
+        repo.store["AAPL"] = _resolved_orm_row("AAPL")  # pre-cached → cache hit
+        resolver = InstrumentMetadataService(
+            provider=provider,
+            repository=cast(SyncInstrumentMetadataRepository, repo),
+        )
+
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            service = self._service(
+                mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+            )
+            service.import_directory(
+                source_dir=source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+            )
+
+        # AAPL was already RESOLVED → provider NOT hit; the others are upserted.
+        assert provider.calls == ["ARKK", "SPY"]
+        assert set(repo.store) == {"AAPL", "ARKK", "SPY"}
+
+    def test_skipped_ticker_does_not_resolve(
+        self,
+        idempotent_source_dir,
+        mock_catalog_manager,
+        mock_instrument_mapper,
+        stateful_metadata_service,
+        bars_by_ticker,
+    ):
+        resolver = MagicMock()
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+        _force_bar_end_to_2025_01_15(bars_by_ticker)
+
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            service = self._service(
+                mock_catalog_manager, stateful_metadata_service, mock_instrument_mapper, resolver
+            )
+            service.import_directory(
+                source_dir=idempotent_source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+            resolves_after_first = resolver.resolve.call_count
+
+            # Second run: everything is complete → all skipped → no new resolves.
+            service.import_directory(
+                source_dir=idempotent_source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+
+        assert resolves_after_first == 2  # AAPL + SPY on the first (parsing) run
+        assert resolver.resolve.call_count == resolves_after_first  # no new calls
+
+    def test_resolver_fault_does_not_fail_bar_import(
+        self,
+        source_dir,
+        mock_catalog_manager,
+        mock_metadata_service,
+        mock_instrument_mapper,
+        bars_by_ticker,
+    ):
+        resolver = MagicMock()
+        resolver.resolve.side_effect = RuntimeError("provider exploded")
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            service = self._service(
+                mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+            )
+            results = service.import_directory(
+                source_dir=source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+            )
+
+        assert all(r.status == "success" for r in results)
+        assert resolver.resolve.call_count == 3

--- a/tests/unit/cli/commands/test_import_data.py
+++ b/tests/unit/cli/commands/test_import_data.py
@@ -129,6 +129,101 @@ class TestParseTimeframes:
         with pytest.raises(click.BadParameter):
             parse_timeframes("weekly")
 
+    @pytest.mark.unit
+    def test_30min_token(self):
+        """Story 2.4 AC3: the 30-minute convention is a valid timeframe token."""
+        from src.cli.commands.import_data import parse_timeframes
+
+        assert parse_timeframes("30min") == ["30-MINUTE-LAST"]
+
+
+# ---------------------------------------------------------------------------
+# Timeframe resolution (Story 2.4 AC2/AC3)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTimeframes:
+    """ETF imports default to all five native timeframes; explicit choice wins."""
+
+    @pytest.mark.unit
+    def test_etf_default_is_all_five_native(self):
+        from src.cli.commands.import_data import resolve_timeframes
+        from src.models.catalog import AssetClass
+
+        assert resolve_timeframes(None, AssetClass.ETF) == [
+            "1-DAY-LAST",
+            "1-HOUR-LAST",
+            "30-MINUTE-LAST",
+            "5-MINUTE-LAST",
+            "1-MINUTE-LAST",
+        ]
+
+    @pytest.mark.unit
+    def test_non_etf_default_is_daily(self):
+        from src.cli.commands.import_data import resolve_timeframes
+        from src.models.catalog import AssetClass
+
+        assert resolve_timeframes(None, AssetClass.STOCK) == ["1-DAY-LAST"]
+
+    @pytest.mark.unit
+    def test_explicit_timeframe_wins_for_etf(self):
+        from src.cli.commands.import_data import resolve_timeframes
+        from src.models.catalog import AssetClass
+
+        assert resolve_timeframes("30min", AssetClass.ETF) == ["30-MINUTE-LAST"]
+        assert resolve_timeframes("daily,hourly", AssetClass.ETF) == [
+            "1-DAY-LAST",
+            "1-HOUR-LAST",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Metadata resolver wiring (Story 2.4 AC4)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMetadataResolver:
+    """ETF imports get a cache-first resolver; non-ETF and unconfigured FMP skip."""
+
+    @staticmethod
+    def _fmp(api_key: str):
+        from src.config import FMPSettings
+
+        return FMPSettings(fmp_api_key=api_key)
+
+    @pytest.mark.unit
+    def test_non_etf_returns_none(self):
+        from unittest.mock import MagicMock
+
+        from src.cli.commands.import_data import _build_metadata_resolver
+        from src.models.catalog import AssetClass
+
+        result = _build_metadata_resolver(MagicMock(), AssetClass.STOCK, self._fmp("present"))
+        assert result is None
+
+    @pytest.mark.unit
+    def test_etf_without_api_key_returns_none(self):
+        from unittest.mock import MagicMock
+
+        from src.cli.commands.import_data import _build_metadata_resolver
+        from src.models.catalog import AssetClass
+
+        result = _build_metadata_resolver(MagicMock(), AssetClass.ETF, self._fmp(""))
+        assert result is None
+
+    @pytest.mark.unit
+    def test_etf_with_api_key_builds_resolver_without_network(self):
+        from unittest.mock import MagicMock
+
+        from src.cli.commands.import_data import _build_metadata_resolver
+        from src.models.catalog import AssetClass
+        from src.services.metadata.instrument_metadata_service import (
+            InstrumentMetadataService,
+        )
+
+        result = _build_metadata_resolver(MagicMock(), AssetClass.ETF, self._fmp("test-key"))
+        assert isinstance(result, InstrumentMetadataService)
+
 
 # ---------------------------------------------------------------------------
 # CLI argument parsing tests (Task 1.1)

--- a/tests/unit/services/firstrate/test_import_service.py
+++ b/tests/unit/services/firstrate/test_import_service.py
@@ -226,6 +226,36 @@ class TestDiscoverTickers:
         result = service._discover_tickers(tmp_path)
         assert result[0][0] == "AAPL"
 
+    def test_filters_tokenized_files_by_requested_timeframe(self, service, tmp_path):
+        """Story 2.4: a per-timeframe pass only sees files of that timeframe.
+
+        Guards against the all-5 ETF default re-parsing every timeframe's file
+        under the wrong BarType when the source mixes timeframes in one tree.
+        """
+        s_dir = tmp_path / "S"
+        s_dir.mkdir()
+        (s_dir / "SPY_full_1day_adjsplitdiv.txt").write_text("data")
+        (s_dir / "SPY_full_1hour_adjsplitdiv.txt").write_text("data")
+        (s_dir / "SPY_full_30min_adjsplitdiv.txt").write_text("data")
+
+        day = service._discover_tickers(tmp_path, "1-DAY-LAST")
+        assert [p.name for _, p in day] == ["SPY_full_1day_adjsplitdiv.txt"]
+
+        hour = service._discover_tickers(tmp_path, "1-HOUR-LAST")
+        assert [p.name for _, p in hour] == ["SPY_full_1hour_adjsplitdiv.txt"]
+
+        thirty = service._discover_tickers(tmp_path, "30-MINUTE-LAST")
+        assert [p.name for _, p in thirty] == ["SPY_full_30min_adjsplitdiv.txt"]
+
+    def test_untokenized_files_included_for_any_timeframe(self, service, tmp_path):
+        """Plain filenames (no tf token) are timeframe-agnostic and always kept."""
+        a_dir = tmp_path / "A"
+        a_dir.mkdir()
+        (a_dir / "AAPL.txt").write_text("data")
+
+        result = service._discover_tickers(tmp_path, "30-MINUTE-LAST")
+        assert [t for t, _ in result] == ["AAPL"]
+
 
 # ---------------------------------------------------------------------------
 # Task 3: Per-ticker import orchestration


### PR DESCRIPTION
Implements Story 2.4: extract→parse (6-col)→resolve metadata cache-first→write Nautilus Parquet to the isolated catalog (`{INSTRUMENT_ID}/{BAR_TYPE}/*.parquet`), all 5 timeframes + `--timeframe` filter. (Also marks story 2-3 done — merged via PR #25.)

---
**Stacked PR — merge in order:** #2.4 → #2.5 → #2.6 → #2.7. Built autonomously by the BMAD harness `dev_loop` (run 20260629-185438); verify passed (ruff+mypy+unit+component, traceability unmet=0). No migration, no new deps.