### PR TITLE
Story 2.6: Idempotent Re-runs via Date-Range Comparison

### DIFF
--- a/_bmad-output/implementation-artifacts/2-6-idempotent-re-runs-via-date-range-comparison.md
+++ b/_bmad-output/implementation-artifacts/2-6-idempotent-re-runs-via-date-range-comparison.md
@@ -1,0 +1,154 @@
+# Story 2.6: Idempotent Re-runs via Date-Range Comparison
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the operator,
+I want re-running the import to skip already-complete tickers and re-import only the incomplete ones,
+so that recovery after interruption is cheap, repeatable, and free of duplicate data — and a re-run that
+touches nothing rewrites no Parquet and makes no FMP calls.
+
+## Acceptance Criteria
+
+1. **AC1 — Date-range comparison re-imports only incomplete tickers (Phase 1 behavior preserved).**
+   Given a prior partial import, When the same import command is re-run, Then date-range comparison identifies
+   complete vs. incomplete tickers and re-imports only the incomplete ones.
+
+2. **AC2 — Already-resolved tickers hit the FMP cache (near-100% cache hit).**
+   Given already-resolved tickers, When the re-run processes them, Then the FMP cache prevents redundant
+   metadata re-fetching — the provider (FMP) is not called again for a ticker already `RESOLVED`.
+
+3. **AC3 — A re-run that touches nothing rewrites no Parquet and makes no FMP calls.**
+   Given a re-run where all tickers are already complete, When the import runs, Then no Parquet is rewritten
+   (no `catalog.write_data`) and no FMP calls are made (no provider `resolve`).
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Confirm the date-range classifier covers AC1 (build ON Phase 1, do NOT rewrite) (AC: #1)**
+  - [x] The idempotent re-run classifier already exists: `ImportService._classify_ticker` decides
+        `skipped` / `reimported` / `new` from the `CatalogInstrument` metadata row plus the cheap
+        `source_probe.compute_source_last_date` last-date probe (ADR-5: metadata, not the filesystem, is the
+        gatekeeper). Day-granularity comparison for `DAY` aggregation; full-datetime for intraday. No change to
+        this logic — Story 2.6 preserves Phase 1 behavior for the ETF path and proves it with ETF-context tests.
+
+- [x] **Task 2 — Confirm cache-first metadata resolution covers AC2 (build ON Story 2.4) (AC: #2)**
+  - [x] `ImportService._resolve_metadata` delegates to the Epic-1 `InstrumentMetadataService.resolve`, which is
+        cache-first (only a `RESOLVED` row short-circuits the provider) and self-upserts. The in-run
+        `_resolved_tickers` set dedups across the per-timeframe passes; the DB-backed `RESOLVED` row dedups
+        across separate runs. No change — Story 2.6 proves the cross-run cache hit with a counting provider.
+
+- [x] **Task 3 — Confirm the skip short-circuit covers AC3 (AC: #3)**
+  - [x] In `_import_ticker`, a `"skipped"` decision returns immediately — before `_resolve_metadata` (no
+        provider call) and before `catalog.delete_data_range` / `catalog.write_data` (no Parquet rewrite). An
+        all-complete re-run therefore does zero writes and zero FMP calls. No change — Story 2.6 proves the
+        combined guarantee in one all-complete re-run with the real cache-first resolver.
+
+- [x] **Task 4 — Tests mapping each AC to a passing test, fixtures/doubles only (AC: #1, #2, #3)**
+  - [x] Component (`tests/component/services/firstrate/test_import_service.py`, new
+        `TestStory26IdempotentRerun` class), reusing the existing in-memory doubles
+        (`stateful_metadata_service`, `_FakeMetadataProvider`, `_FakeMetadataRepo`,
+        `_install_parser_and_readback`, `_force_bar_end_to_2025_01_15`) — no real import, no network, no
+        Postgres, no DB:
+    - [x] **AC1:** run 1 imports two tickers; rewind one metadata row to a partial date-range while leaving the
+          other complete; the re-run re-imports only the incomplete ticker (one more `write_data`) and skips the
+          complete one.
+    - [x] **AC2:** wire the **real** cache-first `InstrumentMetadataService` (counting `_FakeMetadataProvider` +
+          in-memory `_FakeMetadataRepo`) across two `ImportService` instances sharing one resolver; force a
+          re-import on run 2 (source advanced) so `resolve()` is actually invoked — and assert the provider is
+          **not** called again (cache hit) for the already-`RESOLVED` ticker.
+    - [x] **AC3:** with the real counting resolver, an all-complete re-run makes **zero** new `write_data` calls
+          and **zero** new provider calls (no Parquet rewrite, no FMP).
+  - [x] Existing coverage kept green and cross-referenced: `TestIdempotentRerun` (Phase-1 skip/reimport/orphan,
+        AC1), `TestMetadataResolveWiring::test_cache_first_resolved_ticker_skips_provider` (AC2),
+        `TestMetadataResolveWiring::test_skipped_ticker_does_not_resolve` (AC3), and the
+        `TestClassifyTicker` unit suite (AC1 edge cases).
+
+- [x] **Task 5 — Gates**
+  - [x] `uv run ruff check .` clean; `uv run mypy .` (no NEW errors vs the documented baseline);
+        `make test-unit` + `make test-component` green for the touched areas.
+
+## Dev Notes
+
+### Build ON the existing pipeline — do NOT rewrite it
+Story 2.6 is idempotency that **already exists** for the Phase-1 stocks path and was wired through to the ETF
+path in Stories 2.4–2.5. This story preserves that behavior for ETFs and proves all three ACs with
+ETF-context, fixture-only tests. The three load-bearing pieces (none changed):
+
+- `src/services/firstrate/import_service.py`
+  - `_classify_ticker` — date-range comparison (`skipped` / `reimported` / `new`) from the metadata row +
+    `compute_source_last_date`. **AC1.**
+  - `_resolve_metadata` — cache-first resolution via the injected Epic-1 service, with the in-run
+    `_resolved_tickers` dedup; faults isolated. **AC2.**
+  - `_import_ticker` — the `"skipped"` decision returns before any `resolve()` / `delete_data_range` /
+    `write_data`. **AC3.**
+- `src/services/firstrate/source_probe.py` — `compute_source_last_date` (Nautilus-free, streams the file;
+  ET→UTC parity with the parser) is the cheap last-date probe the classifier compares against.
+- `src/services/metadata/instrument_metadata_service.py` — `resolve()` is cache-first (only a `RESOLVED` row
+  short-circuits the provider) and self-upserts; this is the FMP-cache mechanism behind AC2/AC3.
+
+### Why no code change and no migration
+The classifier and cache-first resolver satisfy AC1–AC3 as written; `instrument_metadata` already exists
+(Epic 1). Adding code purely to re-state existing behavior would violate the harness's "build ON existing,
+do not rewrite" guardrail. The deliverable is the per-AC proving tests (verification guidance: every AC maps
+to a passing fixture-based unit/component test).
+
+### Out of scope (later stories / epics — do NOT implement)
+- Import summary + `ResolutionSummary` line / progress reporting (Story 2.7).
+- Venue resolution (Epic 3), explorer (Epic 4), backtests (Epic 5).
+- Any DB schema change / Alembic migration (none needed), and any change to financial calculations or
+  previously produced numbers.
+
+### Project Structure Notes
+- **Modified (tests only):** `tests/component/services/firstrate/test_import_service.py`
+  (new `TestStory26IdempotentRerun` class). No production source changes.
+- Stay under size limits; the test class reuses the file's existing fixtures and in-memory doubles.
+
+### Testing standards
+- **Tiers:** Component for the full `import_directory` re-run with the existing test doubles; the Phase-1
+  classifier edge cases are already covered by unit tests. No engine, no Postgres, no network, no real import.
+  Commands: `make test-unit`, `make test-component`.
+- **Import gate (F401/F821):** add imports and usages in the same edit.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-2.6] — idempotent re-runs via date-range comparison;
+  FMP cache prevents redundant re-fetch; a no-op re-run writes nothing (lines 531-549); FR16, NFR10, NFR14
+- [Source: harness-epic2-rest-spec.md#Story-2.6] — scoped ACs + TEA verification guidance (fixtures only,
+  no real import/network/DB)
+- [Source: src/services/firstrate/import_service.py] — `_classify_ticker` (AC1), `_resolve_metadata` (AC2),
+  `_import_ticker` skip short-circuit (AC3)
+- [Source: src/services/firstrate/source_probe.py] — `compute_source_last_date` last-date probe (AC1)
+- [Source: src/services/metadata/instrument_metadata_service.py:48-62] — cache-first `resolve()` (AC2/AC3)
+- [Source: _bmad-output/planning-artifacts/architecture.md ADR-5] — metadata row (not the Parquet file) is the
+  import gatekeeper for the classifier
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8
+
+### Debug Log References
+
+### Completion Notes List
+
+- **AC1:** `_classify_ticker` (date-range comparison, Phase-1) preserved for the ETF path; proven by a re-run
+  that re-imports only the rewound/incomplete ticker and skips the complete one.
+- **AC2:** the Epic-1 cache-first `InstrumentMetadataService.resolve` plus the `_resolved_tickers` in-run dedup;
+  proven across two `ImportService` instances sharing one resolver — a forced re-import on run 2 invokes
+  `resolve()` but the counting provider is NOT hit again for the already-`RESOLVED` ticker.
+- **AC3:** the `"skipped"` short-circuit returns before any `resolve()` / `write_data`; proven by an
+  all-complete re-run making zero new `write_data` and zero new provider calls.
+- **No production change / no migration:** behavior already present from Phase 1 + Stories 2.4–2.5; this story
+  adds the per-AC proving tests only.
+- **Gates:** `ruff check .` clean; `mypy .` no new errors; `make test-unit` + `make test-component` green.
+
+### File List
+
+- `tests/component/services/firstrate/test_import_service.py` (new `TestStory26IdempotentRerun` class — AC1/AC2/AC3 proving tests)
+- `_bmad-output/implementation-artifacts/2-6-idempotent-re-runs-via-date-range-comparison.md` (this story)
+</content>
+</invoke>

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-06-17
-last_updated: "2026-06-28"  # Story 2.3 (dry-run scan with FMP-aware estimate) in development
+last_updated: "2026-06-29"  # Story 2.6 (idempotent re-runs via date-range comparison) done
 project: Trading-ntrader
 project_key: NOKEY
 tracking_system: file-system
@@ -66,7 +66,7 @@ development_status:
   2-3-dry-run-scan-with-fmp-aware-estimate: done
   2-4-etf-import-parse-convert-and-write-to-isolated-catalog: done
   2-5-import-verification-ohlc-sanity-row-count-parity-and-sample-point: done
-  2-6-idempotent-re-runs-via-date-range-comparison: backlog
+  2-6-idempotent-re-runs-via-date-range-comparison: done
   2-7-import-summary-and-progress-reporting: backlog
   epic-2-retrospective: optional
 

--- a/tests/component/services/firstrate/test_import_service.py
+++ b/tests/component/services/firstrate/test_import_service.py
@@ -1096,3 +1096,216 @@ class TestOhlcSanitySurfacing:
         # Logged via structured logging (AC4 — never silent).
         events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
         assert "ohlc_sanity_flagged" in events
+
+
+# ---------------------------------------------------------------------------
+# Story 2.6 — Idempotent re-runs via date-range comparison
+#
+# Maps each scoped AC to a passing test that exercises the EXISTING Phase-1
+# classifier + Story-2.4 cache-first resolver through ``import_directory`` with
+# the established in-memory doubles (no real import / network / Postgres / DB):
+#   AC1 — date-range comparison re-imports only the incomplete ticker.
+#   AC2 — an already-RESOLVED ticker that is re-processed hits the FMP cache
+#         (the provider is NOT called again).
+#   AC3 — an all-complete re-run rewrites no Parquet AND makes no FMP calls.
+# ---------------------------------------------------------------------------
+
+
+def _make_cache_first_resolver():
+    """Wire the REAL cache-first resolver over the in-memory provider + repo.
+
+    Returns ``(resolver, provider, repo)`` so a test can assert on the counting
+    provider's ``calls`` (actual FMP fetches) while the resolver enforces the
+    cache-first contract exactly as production does.
+    """
+    from typing import cast
+
+    from src.db.repositories.instrument_metadata_repository_sync import (
+        SyncInstrumentMetadataRepository,
+    )
+    from src.services.metadata.instrument_metadata_service import (
+        InstrumentMetadataService,
+    )
+
+    provider = _FakeMetadataProvider()
+    repo = _FakeMetadataRepo()
+    resolver = InstrumentMetadataService(
+        provider=provider,
+        repository=cast(SyncInstrumentMetadataRepository, repo),
+    )
+    return resolver, provider, repo
+
+
+@pytest.mark.component
+class TestStory26IdempotentRerun:
+    """Story 2.6: a re-run skips complete tickers, reuses the cache, and no-ops when unchanged."""
+
+    def test_ac1_rerun_reimports_only_incomplete_tickers(
+        self,
+        idempotent_source_dir,
+        mock_catalog_manager,
+        mock_instrument_mapper,
+        stateful_metadata_service,
+        bars_by_ticker,
+    ):
+        """AC1: date-range comparison re-imports only the incomplete ticker."""
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+        _force_bar_end_to_2025_01_15(bars_by_ticker)
+        mock_catalog = mock_catalog_manager.resolve_catalog.return_value
+
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            service = ImportService(
+                catalog_manager=mock_catalog_manager,
+                metadata_service=stateful_metadata_service,
+                instrument_mapper=mock_instrument_mapper,
+            )
+            # Run 1: AAPL + SPY both import fresh, metadata end set to 2025-01-15.
+            service.import_directory(
+                source_dir=idempotent_source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+
+            # Simulate a partial prior import for AAPL only — rewind its
+            # date_range_end behind the source while keeping bar_count > 0.
+            # SPY stays complete and must be skipped on the re-run.
+            aapl_row = stateful_metadata_service.storage[(CATALOG_NAME, "AAPL")]
+            aapl_row.date_range_end = stateful_metadata_service._datetime(
+                2024, 12, 31, tzinfo=stateful_metadata_service._tz
+            )
+            aapl_row.bar_count_daily = 5
+
+            writes_before_rerun = mock_catalog.write_data.call_count
+            second = service.import_directory(
+                source_dir=idempotent_source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+
+        by_ticker = {r.ticker: r for r in second}
+        assert by_ticker["AAPL"].outcome == "reimported"
+        assert by_ticker["SPY"].outcome == "skipped"
+        # Exactly one Parquet (re)write on the re-run — AAPL only, never SPY.
+        assert mock_catalog.write_data.call_count == writes_before_rerun + 1
+
+    def test_ac2_reprocessed_ticker_hits_fmp_cache(
+        self,
+        idempotent_source_dir,
+        mock_catalog_manager,
+        mock_instrument_mapper,
+        stateful_metadata_service,
+        bars_by_ticker,
+    ):
+        """AC2: a re-processed already-RESOLVED ticker hits the cache — provider not re-called."""
+        resolver, provider, _repo = _make_cache_first_resolver()
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+        _force_bar_end_to_2025_01_15(bars_by_ticker)
+
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            # Run 1: a fresh service resolves each ticker once via the provider.
+            first_service = ImportService(
+                catalog_manager=mock_catalog_manager,
+                metadata_service=stateful_metadata_service,
+                instrument_mapper=mock_instrument_mapper,
+                metadata_resolver=resolver,
+            )
+            first_service.import_directory(
+                source_dir=idempotent_source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+            assert sorted(provider.calls) == ["AAPL", "SPY"]
+            provider_calls_after_first = list(provider.calls)
+
+            # Force AAPL to re-import on the next run (source advanced past metadata),
+            # so resolve() is genuinely invoked for it again — the AC2 scenario.
+            aapl_row = stateful_metadata_service.storage[(CATALOG_NAME, "AAPL")]
+            aapl_row.date_range_end = stateful_metadata_service._datetime(
+                2024, 12, 31, tzinfo=stateful_metadata_service._tz
+            )
+            aapl_row.bar_count_daily = 5
+
+            # Run 2: a brand-new service (fresh in-run dedup) sharing the SAME
+            # cache-first resolver. Spy on resolve() to prove it IS invoked.
+            resolver_spy = MagicMock(wraps=resolver)
+            second_service = ImportService(
+                catalog_manager=mock_catalog_manager,
+                metadata_service=stateful_metadata_service,
+                instrument_mapper=mock_instrument_mapper,
+                metadata_resolver=resolver_spy,
+            )
+            second = second_service.import_directory(
+                source_dir=idempotent_source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+
+        by_ticker = {r.ticker: r for r in second}
+        assert by_ticker["AAPL"].outcome == "reimported"  # AAPL is processed again
+        # resolve() WAS invoked for AAPL on the re-run (it is re-processed)...
+        resolved_on_rerun = [c.args[0] for c in resolver_spy.resolve.call_args_list]
+        assert "AAPL" in resolved_on_rerun
+        # ...but the FMP provider was NOT called again — cache hit (near-100%).
+        assert provider.calls == provider_calls_after_first
+
+    def test_ac3_complete_rerun_no_parquet_and_no_fmp(
+        self,
+        idempotent_source_dir,
+        mock_catalog_manager,
+        mock_instrument_mapper,
+        stateful_metadata_service,
+        bars_by_ticker,
+    ):
+        """AC3: an all-complete re-run rewrites no Parquet and makes no FMP calls."""
+        resolver, provider, _repo = _make_cache_first_resolver()
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+        _force_bar_end_to_2025_01_15(bars_by_ticker)
+        mock_catalog = mock_catalog_manager.resolve_catalog.return_value
+
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            # Run 1: import both tickers — writes Parquet, resolves via provider.
+            first_service = ImportService(
+                catalog_manager=mock_catalog_manager,
+                metadata_service=stateful_metadata_service,
+                instrument_mapper=mock_instrument_mapper,
+                metadata_resolver=resolver,
+            )
+            first_service.import_directory(
+                source_dir=idempotent_source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+            writes_after_first = mock_catalog.write_data.call_count
+            provider_calls_after_first = list(provider.calls)
+            assert writes_after_first == 2  # AAPL + SPY
+            assert sorted(provider_calls_after_first) == ["AAPL", "SPY"]
+
+            # Run 2: everything is complete (metadata end == source last date) →
+            # all skipped. A fresh service ensures the no-op is not an artifact of
+            # the in-run dedup set.
+            second_service = ImportService(
+                catalog_manager=mock_catalog_manager,
+                metadata_service=stateful_metadata_service,
+                instrument_mapper=mock_instrument_mapper,
+                metadata_resolver=resolver,
+            )
+            second = second_service.import_directory(
+                source_dir=idempotent_source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+
+        assert {r.outcome for r in second} == {"skipped"}
+        # AC3: no Parquet rewritten...
+        assert mock_catalog.write_data.call_count == writes_after_first
+        # ...and no FMP calls made.
+        assert provider.calls == provider_calls_after_first


### PR DESCRIPTION
Implements Story 2.6: re-runs skip complete tickers via date-range comparison, hit the FMP cache (no redundant fetch), and no-op when nothing changed. **Base: feat/story-2.5** (merge after 2.5).

---
**Stacked PR — merge in order:** #2.4 → #2.5 → #2.6 → #2.7. Built autonomously by the BMAD harness `dev_loop` (run 20260629-185438); verify passed (ruff+mypy+unit+component, traceability unmet=0). No migration, no new deps.