### PR TITLE
Story 2.7: Import Summary & Progress Reporting

### DIFF
--- a/_bmad-output/implementation-artifacts/2-7-import-summary-and-progress-reporting.md
+++ b/_bmad-output/implementation-artifacts/2-7-import-summary-and-progress-reporting.md
@@ -1,0 +1,171 @@
+# Story 2.7: Import Summary & Progress Reporting
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the operator,
+I want progress reported during the import and a summary report at the end that also folds in the Epic 1
+resolution counts,
+so that I can monitor a long ETF batch as it runs and review exactly what happened — tickers processed, rows
+imported, failures with reasons, and how metadata resolution went.
+
+## Acceptance Criteria
+
+1. **AC1 — Progress during the import via structured logging.**
+   Given an import in progress, When it runs, Then progress is reported (current ticker, running counts,
+   errors) via structured logging.
+
+2. **AC2 — End-of-run summary incorporates the Epic 1 `ResolutionSummary`.**
+   Given a completed import, When the summary is produced, Then it reports tickers processed, rows imported,
+   and failures with reasons, AND it incorporates the Epic 1 `ResolutionSummary`
+   (resolved / descriptive-gaps / venue-unresolved counts).
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Emit per-ticker progress with running counts (AC: #1)**
+  - [x] In `ImportService.import_directory`, after each ticker is imported, emit a structured `import_progress`
+        event carrying `ticker`, `timeframe`, `index`, `total`, the running `success` / `failed` / `skipped`
+        counts, and the `error` string when that ticker failed. Builds ON the existing
+        `import_directory_start` / `import_directory_complete` lines (those stay) — this adds the per-ticker
+        running-count line the AC asks for. No change to the per-ticker import logic.
+
+- [x] **Task 2 — Collect resolved metadata during the run (AC: #2)**
+  - [x] `ImportService._resolve_metadata` already calls the Epic-1 cache-first
+        `InstrumentMetadataService.resolve(ticker)` (Story 2.4) but discards the returned domain
+        `InstrumentMetadata`. Capture it into a per-run, per-ticker dict (`_resolved_metadata`) so each ticker
+        is recorded at most once (mirrors the `_resolved_tickers` dedup). Expose a read-only
+        `resolved_metadata` property returning the collected domain models. Faults stay isolated — a metadata
+        hiccup records nothing and never fails the bar import.
+
+- [x] **Task 3 — Fold `ResolutionSummary` into the end-of-run summary (AC: #2)**
+  - [x] In `import_data._run_import`, after `_print_summary`, build
+        `ResolutionSummary.from_results(import_service.resolved_metadata)` and render it via the existing
+        Story-1.6 `_print_resolution_summary`. Print it only when metadata was actually resolved this run
+        (the ETF path with FMP configured) so the stocks/no-resolver path stays unchanged. The summary section
+        (tickers processed, rows imported, failures with reasons) is the existing `_print_summary` output —
+        unchanged.
+
+- [x] **Task 4 — Tests mapping each AC to a passing test, fixtures/doubles only (AC: #1, #2)**
+  - [x] Unit (`tests/unit/services/firstrate/test_import_service.py`): `_resolve_metadata` collects the
+        resolved domain model and dedups per ticker; the `resolved_metadata` property exposes it; a resolver
+        fault records nothing. `import_directory` emits one `import_progress` line per ticker with running
+        counts (logger monkeypatched).
+  - [x] Component (`tests/component/services/firstrate/test_import_service.py`, new
+        `TestStory27ResolutionSummaryCollection` class) reusing the existing in-memory doubles
+        (`_FakeMetadataProvider`, `_FakeMetadataRepo`, `_install_parser_and_readback`): the real cache-first
+        `InstrumentMetadataService` resolves three tickers across a full `import_directory` run, and
+        `ResolutionSummary.from_results(service.resolved_metadata)` reports the expected resolved count — no
+        real import, no network, no Postgres.
+  - [x] Unit (`tests/unit/cli/commands/test_import_reporting.py`): the existing
+        `build_resolution_summary_text` / `_print_resolution_summary` helpers (Story 1.6) already cover the
+        render; cross-referenced — no duplication.
+
+- [x] **Task 5 — Gates**
+  - [x] `uv run ruff check .` clean; `uv run mypy .` (no NEW errors vs the documented baseline);
+        `make test-unit` + `make test-component` green for the touched areas.
+
+### Review Findings
+
+- [x] [Review][Defer] `ResolutionSummary` has no bucket for a non-throwing `UNRESOLVED` record
+  [src/models/instrument_metadata.py:142-147] — deferred, pre-existing. `from_results` (Story 1.6) counts a
+  record toward `resolved` or `venue_unresolved` by status; a clean-degrade `UNRESOLVED` (not `VENUE_UNRESOLVED`)
+  increments neither, so `resolved + venue_unresolved` can under-count. Pre-existing Epic-1 aggregation
+  semantics — Story 2.7 only reads `from_results`, it does not change it. Whether the FMP provider can return a
+  non-throwing `UNRESOLVED` is an Epic-1/Epic-3 venue-worklist concern.
+- Dismissed (false positives / by design): progress line keys on `status` while the summary keys skipped on
+  `outcome` — no reachable divergence (`_import_ticker` sets both together; `ImportResult` carries both fields);
+  per-timeframe running-count reset is intentional (`import_directory` is a per-timeframe operation and the CLI
+  loops timeframes); all-faulted ETF run prints no Resolution Summary — intended per spec ("printed only when
+  resolution actually ran"); no dedicated CLI-level test for the 3-line fold-in — covered at the service
+  (`resolved_metadata`) + model (`from_results`) level, and a CLI test would need the full DB session path
+  (violates the infra-light guardrail).
+
+## Dev Notes
+
+### Build ON the existing pipeline — do NOT rewrite it
+Most of the reporting surface already exists; Story 2.7 wires the two missing pieces:
+
+- **Progress (AC1):** `import_directory` already logs `import_directory_start` / `import_directory_complete`
+  and the CLI prints a per-ticker `_print_progress_line`. The AC additionally asks for **running counts** in
+  the structured log stream — added as a per-ticker `import_progress` event inside the loop.
+- **Resolution summary (AC2):** the `ResolutionSummary` model (`from_results`), `build_resolution_summary_text`,
+  and `_print_resolution_summary` already exist from Story 1.6 but were never wired into the ETF import path.
+  The import path resolves metadata per ticker (Story 2.4) but threw the results away. Story 2.7 collects them
+  and renders the summary at end-of-run.
+
+### Load-bearing pieces
+- `src/services/firstrate/import_service.py`
+  - `import_directory` — add the `import_progress` running-count line (AC1); collect via `_resolve_metadata`.
+  - `_resolve_metadata` — capture the domain `InstrumentMetadata` returned by the Epic-1 resolver into
+    `_resolved_metadata` (deduped per ticker); faults isolated (record nothing). New `resolved_metadata`
+    property (AC2).
+- `src/cli/commands/import_data.py` — after `_print_summary`, fold in
+  `ResolutionSummary.from_results(import_service.resolved_metadata)` via `_print_resolution_summary` when
+  resolution ran (AC2).
+- `src/cli/commands/import_reporting.py` — `_print_resolution_summary` / `build_resolution_summary_text`
+  (Story 1.6) reused as-is. `_print_summary` (tickers processed, rows, failures) reused as-is.
+- `src/models/instrument_metadata.py` — `ResolutionSummary.from_results` aggregates the three counters.
+
+### Why no migration
+`instrument_metadata` already exists (Epic 1); resolution writes through the existing cache-first service. This
+story only reads back the in-run domain results and renders counts. No schema change, no Alembic migration.
+
+### Out of scope (later stories / epics — do NOT implement)
+- Venue resolution / unresolved-venue report (Epic 3), explorer (Epic 4), backtests (Epic 5).
+- Any DB schema change / Alembic migration (none needed), and any change to financial calculations or
+  previously produced numbers.
+
+### Project Structure Notes
+- **Modified:** `src/services/firstrate/import_service.py` (progress line + resolved-metadata collection),
+  `src/cli/commands/import_data.py` (fold in `ResolutionSummary`).
+- **Tests:** `tests/unit/services/firstrate/test_import_service.py`,
+  `tests/component/services/firstrate/test_import_service.py`.
+- Stay under size limits; reuse existing fixtures and in-memory doubles.
+
+### Testing standards
+- **Tiers:** Unit for the collection/dedup/progress-logging logic with mocked deps; Component for the
+  full `import_directory` run with the real cache-first resolver over in-memory doubles. No engine, no
+  Postgres, no network, no real import. Commands: `make test-unit`, `make test-component`.
+- **Import gate (F401/F821):** add imports and usages in the same edit.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-2.7] — progress (current ticker, running counts,
+  errors) via structured logging; end-of-run summary (processed, rows, failures w/ reasons) incorporating the
+  Epic 1 `ResolutionSummary` (lines 551-566); FR18, FR19
+- [Source: harness-epic2-rest-spec.md#Story-2.7] — scoped ACs + TEA verification guidance (fixtures only,
+  no real import/network/DB)
+- [Source: src/cli/commands/import_reporting.py:245-283] — `build_resolution_summary_text` /
+  `_print_resolution_summary` (Story 1.6), reused
+- [Source: src/models/instrument_metadata.py:105-152] — `ResolutionSummary.from_results`
+- [Source: src/services/firstrate/import_service.py:650-676] — `_resolve_metadata` (Story 2.4 cache-first)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8
+
+### Debug Log References
+
+### Completion Notes List
+
+- **AC1:** `import_directory` now emits a per-ticker `import_progress` structured event with `ticker`,
+  `timeframe`, `index`, `total`, running `success`/`failed`/`skipped` counts, and the `error` on failure.
+- **AC2:** `_resolve_metadata` collects the Epic-1 cache-first resolver's domain `InstrumentMetadata` into a
+  per-run, per-ticker dict; `resolved_metadata` exposes it; the CLI folds
+  `ResolutionSummary.from_results(...)` into the end-of-run summary via the Story-1.6
+  `_print_resolution_summary` (printed only when resolution ran).
+- **No migration:** reads back in-run resolution results; `instrument_metadata` already exists.
+- **Gates:** `ruff check .` clean; `mypy .` no new errors; `make test-unit` + `make test-component` green.
+
+### File List
+
+- `src/services/firstrate/import_service.py` (progress line + resolved-metadata collection + property)
+- `src/cli/commands/import_data.py` (fold `ResolutionSummary` into the end-of-run summary)
+- `tests/unit/services/firstrate/test_import_service.py` (collection/dedup/fault + progress-logging tests)
+- `tests/component/services/firstrate/test_import_service.py` (new `TestStory27ResolutionSummaryCollection`)
+- `_bmad-output/implementation-artifacts/2-7-import-summary-and-progress-reporting.md` (this story)

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,13 @@
+# Deferred Work
+
+Real, non-blocking findings deferred from code reviews. Each entry notes its source and why it was deferred.
+
+## Deferred from: code review of story 2-7-import-summary-and-progress-reporting (2026-06-29)
+
+- **`ResolutionSummary` has no bucket for a non-throwing `UNRESOLVED` record**
+  [src/models/instrument_metadata.py:142-147]. `ResolutionSummary.from_results` (Story 1.6) increments
+  `resolved` or `venue_unresolved` by status; a clean-degrade `UNRESOLVED` record (distinct from the
+  `VENUE_UNRESOLVED` error record) counts toward neither, so `resolved + venue_unresolved` can under-count the
+  tickers actually resolved this run, with no "unresolved" line in the summary table. Pre-existing Epic-1
+  aggregation semantics — Story 2.7's import-summary wiring only reads `from_results`. Revisit alongside the
+  Epic-3 venue worklist / completeness gate, where unresolved-state reporting is in scope.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-06-17
-last_updated: "2026-06-29"  # Story 2.6 (idempotent re-runs via date-range comparison) done
+last_updated: "2026-06-29"  # Story 2.7 (import summary & progress reporting) done
 project: Trading-ntrader
 project_key: NOKEY
 tracking_system: file-system
@@ -67,7 +67,7 @@ development_status:
   2-4-etf-import-parse-convert-and-write-to-isolated-catalog: done
   2-5-import-verification-ohlc-sanity-row-count-parity-and-sample-point: done
   2-6-idempotent-re-runs-via-date-range-comparison: done
-  2-7-import-summary-and-progress-reporting: backlog
+  2-7-import-summary-and-progress-reporting: done
   epic-2-retrospective: optional
 
   # Epic 3: Venue Resolution & Completeness Gate

--- a/src/cli/commands/import_data.py
+++ b/src/cli/commands/import_data.py
@@ -20,11 +20,13 @@ if TYPE_CHECKING:
 
 from src.cli.commands.import_reporting import (
     _print_progress_line,
+    _print_resolution_summary,
     _print_summary,
     determine_exit_code,
 )
 from src.db.exceptions import DatabaseConnectionError
 from src.models.catalog import AssetClass, DryRunReport, ImportResult
+from src.models.instrument_metadata import ResolutionSummary
 from src.services.firstrate.dry_run import (
     _UNKNOWN_TIMEFRAME,
     ResolvedTickerReader,
@@ -379,6 +381,14 @@ def _run_import(
 
     # Summary
     _print_summary(all_results, supplementary_results)
+
+    # Story 2.7 AC2: fold in the Epic-1 ResolutionSummary (resolved /
+    # descriptive-gaps / venue-unresolved) aggregated from the metadata resolved
+    # during this run. Printed only when resolution actually ran (the ETF path
+    # with FMP configured) so the stocks / no-resolver path is unchanged.
+    resolved_metadata = import_service.resolved_metadata
+    if resolved_metadata:
+        _print_resolution_summary(ResolutionSummary.from_results(resolved_metadata))
 
     # Supplementary outcomes are informational only — a supplementary failure
     # must never flip the exit code (AC-3/AC-6); only bar results decide it.

--- a/src/services/firstrate/import_service.py
+++ b/src/services/firstrate/import_service.py
@@ -27,6 +27,7 @@ from src.services.firstrate.parsers.base import get_parser
 from src.services.firstrate.source_probe import compute_source_last_date
 
 if TYPE_CHECKING:
+    from src.models.instrument_metadata import InstrumentMetadata
     from src.services.metadata.instrument_metadata_service import (
         InstrumentMetadataService,
     )
@@ -110,6 +111,22 @@ class ImportService:
         # would re-invoke resolve() N times, re-hitting the provider for every
         # not-yet-RESOLVED ticker on each pass.
         self._resolved_tickers: set[str] = set()
+        # Story 2.7 AC2: the domain InstrumentMetadata returned by the Epic-1
+        # cache-first resolver, captured per ticker (deduped), so the CLI can
+        # fold a ResolutionSummary (resolved / descriptive-gaps / venue-
+        # unresolved) into the end-of-run summary. Keyed by ticker so a ticker
+        # spanning multiple timeframe passes is recorded exactly once.
+        self._resolved_metadata: dict[str, "InstrumentMetadata"] = {}
+
+    @property
+    def resolved_metadata(self) -> "list[InstrumentMetadata]":
+        """Domain metadata resolved this run, deduped per ticker (Story 2.7 AC2).
+
+        Empty when no metadata resolver is injected (the Phase-1 stocks path) or
+        when every resolution faulted. Consumed by the CLI to build the
+        end-of-run ``ResolutionSummary``.
+        """
+        return list(self._resolved_metadata.values())
 
     def import_directory(
         self,
@@ -152,7 +169,10 @@ class ImportService:
         )
 
         results: list[ImportResult] = []
-        for ticker, file_path in tickers:
+        # Running counts for the per-ticker progress line (Story 2.7 AC1).
+        running = {"success": 0, "failed": 0, "skipped": 0}
+        total = len(tickers)
+        for index, (ticker, file_path) in enumerate(tickers, start=1):
             result = self._import_ticker(
                 ticker=ticker,
                 file_path=file_path,
@@ -161,6 +181,28 @@ class ImportService:
                 timeframe=timeframe,
             )
             results.append(result)
+
+            # Story 2.7 AC1: report progress (current ticker, running counts,
+            # errors) via structured logging so a long batch is observable as it
+            # runs — complementing the start/complete bookends. "skipped" is its
+            # own bucket; any non-success/non-skipped status counts as failed.
+            if result.status == "success":
+                running["success"] += 1
+            elif result.status == "skipped":
+                running["skipped"] += 1
+            else:
+                running["failed"] += 1
+            logger.info(
+                "import_progress",
+                ticker=ticker,
+                timeframe=timeframe,
+                index=index,
+                total=total,
+                success=running["success"],
+                failed=running["failed"],
+                skipped=running["skipped"],
+                error=result.error if result.status == "failed" else None,
+            )
 
         success = sum(1 for r in results if r.status == "success")
         failed = sum(1 for r in results if r.status == "failed")
@@ -671,7 +713,10 @@ class ImportService:
         # every subsequent timeframe pass within the same run.
         self._resolved_tickers.add(ticker)
         try:
-            self._metadata_resolver.resolve(ticker)
+            # Capture the domain result (Story 2.7 AC2) so the end-of-run summary
+            # can aggregate it into a ResolutionSummary. Only successful
+            # resolutions are recorded; a fault records nothing.
+            self._resolved_metadata[ticker] = self._metadata_resolver.resolve(ticker)
         except Exception as e:  # noqa: BLE001 — isolate metadata faults from bars
             logger.warning("metadata_resolution_failed", ticker=ticker, error=str(e))
 

--- a/tests/component/services/firstrate/test_import_service.py
+++ b/tests/component/services/firstrate/test_import_service.py
@@ -1309,3 +1309,87 @@ class TestStory26IdempotentRerun:
         assert mock_catalog.write_data.call_count == writes_after_first
         # ...and no FMP calls made.
         assert provider.calls == provider_calls_after_first
+
+
+@pytest.mark.component
+class TestStory27ResolutionSummaryCollection:
+    """Story 2.7 AC2: resolved metadata is collected and aggregates to a summary."""
+
+    def _service(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+    ):
+        return ImportService(
+            catalog_manager=mock_catalog_manager,
+            metadata_service=mock_metadata_service,
+            instrument_mapper=mock_instrument_mapper,
+            metadata_resolver=resolver,
+        )
+
+    def test_resolved_metadata_aggregates_to_resolution_summary(
+        self,
+        source_dir,
+        mock_catalog_manager,
+        mock_metadata_service,
+        mock_instrument_mapper,
+        bars_by_ticker,
+    ):
+        from typing import cast
+
+        from src.db.repositories.instrument_metadata_repository_sync import (
+            SyncInstrumentMetadataRepository,
+        )
+        from src.models.instrument_metadata import ResolutionSummary
+        from src.services.metadata.instrument_metadata_service import (
+            InstrumentMetadataService,
+        )
+
+        provider = _FakeMetadataProvider()  # returns RESOLVED rows
+        repo = _FakeMetadataRepo()
+        resolver = InstrumentMetadataService(
+            provider=provider,
+            repository=cast(SyncInstrumentMetadataRepository, repo),
+        )
+
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            service = self._service(
+                mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+            )
+            service.import_directory(
+                source_dir=source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+            )
+
+        collected = service.resolved_metadata
+        assert sorted(m.ticker for m in collected) == ["AAPL", "ARKK", "SPY"]
+
+        summary = ResolutionSummary.from_results(collected)
+        assert summary.resolved == 3
+        assert summary.venue_unresolved == 0
+        assert summary.descriptive_gaps == 0
+
+    def test_no_resolver_collects_nothing(
+        self,
+        source_dir,
+        mock_catalog_manager,
+        mock_metadata_service,
+        mock_instrument_mapper,
+        bars_by_ticker,
+    ):
+        cm, mock_parser = _install_parser_and_readback(mock_catalog_manager, bars_by_ticker)
+        with cm as mock_get_parser:
+            mock_get_parser.return_value = mock_parser
+            service = ImportService(
+                catalog_manager=mock_catalog_manager,
+                metadata_service=mock_metadata_service,
+                instrument_mapper=mock_instrument_mapper,
+            )
+            service.import_directory(
+                source_dir=source_dir,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+            )
+
+        assert service.resolved_metadata == []

--- a/tests/unit/services/firstrate/test_import_service.py
+++ b/tests/unit/services/firstrate/test_import_service.py
@@ -1125,3 +1125,171 @@ class TestImportDirectoryCompleteLogLine:
         assert payload["new"] == 1
         assert payload["reimported"] == 0
         assert payload["failed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Story 2.7: resolved-metadata collection + progress logging
+# ---------------------------------------------------------------------------
+
+
+def _domain_metadata(ticker: str, status=None):
+    """Build a domain InstrumentMetadata for resolver-return stubbing."""
+    from src.models.instrument_metadata import (
+        InstrumentMetadata,
+        ResolutionStatus,
+    )
+
+    return InstrumentMetadata(
+        ticker=ticker,
+        metadata_provider="FAKE",
+        venue="ARCA",
+        currency="USD",
+        company_name="Fake Co",
+        sector="Funds",
+        industry="ETF",
+        country="US",
+        resolution_status=status or ResolutionStatus.RESOLVED,
+    )
+
+
+@pytest.mark.unit
+class TestResolvedMetadataCollection:
+    """Story 2.7 AC2: the resolver's domain results are captured per run."""
+
+    def _service_with_resolver(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+    ):
+        return ImportService(
+            catalog_manager=mock_catalog_manager,
+            metadata_service=mock_metadata_service,
+            instrument_mapper=mock_instrument_mapper,
+            metadata_resolver=resolver,
+        )
+
+    def test_resolve_metadata_collects_domain_result(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
+    ):
+        resolver = MagicMock()
+        resolver.resolve.return_value = _domain_metadata("SPY")
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        svc._resolve_metadata("SPY")
+
+        collected = svc.resolved_metadata
+        assert [m.ticker for m in collected] == ["SPY"]
+
+    def test_resolved_metadata_deduped_per_ticker(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
+    ):
+        resolver = MagicMock()
+        resolver.resolve.return_value = _domain_metadata("SPY")
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        svc._resolve_metadata("SPY")
+        svc._resolve_metadata("SPY")  # second pass (e.g. another timeframe)
+
+        assert resolver.resolve.call_count == 1  # in-run dedup
+        assert [m.ticker for m in svc.resolved_metadata] == ["SPY"]
+
+    def test_resolver_fault_records_nothing(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
+    ):
+        resolver = MagicMock()
+        resolver.resolve.side_effect = RuntimeError("provider down")
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        svc._resolve_metadata("SPY")  # must not raise
+
+        assert svc.resolved_metadata == []
+
+    def test_no_resolver_means_empty_collection(self, service):
+        # The Phase-1 stocks path injects no resolver — nothing collected.
+        service._resolve_metadata("SPY")
+        assert service.resolved_metadata == []
+
+
+@pytest.mark.unit
+class TestImportProgressLogging:
+    """Story 2.7 AC1: per-ticker progress with running counts via structlog."""
+
+    def test_progress_line_emitted_per_ticker_with_running_counts(
+        self, configured_service, mock_metadata_service, mock_bars, tmp_path
+    ):
+        # Two tickers, both fresh → both imported as "new".
+        (tmp_path / "A").mkdir()
+        (tmp_path / "S").mkdir()
+        _write_daily_csv(tmp_path / "A" / "AAPL.txt", "2025-02-01")
+        _write_daily_csv(tmp_path / "S" / "SPY.txt", "2025-02-01")
+        mock_metadata_service.get_instrument_sync.return_value = _fresh_instrument_row()
+
+        with (
+            patch("src.services.firstrate.import_service.get_parser") as mock_get_parser,
+            patch("src.services.firstrate.import_service.logger") as mock_logger,
+        ):
+            mock_parser = MagicMock()
+            mock_parser.parse_file.return_value = mock_bars
+            mock_get_parser.return_value = mock_parser
+
+            configured_service.import_directory(
+                source_dir=tmp_path,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+
+        progress_calls = [
+            call.kwargs
+            for call in mock_logger.info.call_args_list
+            if call.args and call.args[0] == "import_progress"
+        ]
+        # One progress line per ticker.
+        assert len(progress_calls) == 2
+        # Discovery is sorted: AAPL (A/) before SPY (S/).
+        assert [c["ticker"] for c in progress_calls] == ["AAPL", "SPY"]
+        assert [c["index"] for c in progress_calls] == [1, 2]
+        assert all(c["total"] == 2 for c in progress_calls)
+        # Running success count increments; the final line reflects both done.
+        assert progress_calls[0]["success"] == 1
+        assert progress_calls[-1]["success"] == 2
+        assert progress_calls[-1]["failed"] == 0
+        assert progress_calls[-1]["skipped"] == 0
+
+    def test_progress_line_carries_error_on_failure(
+        self, configured_service, mock_metadata_service, mock_instrument_mapper, mock_bars, tmp_path
+    ):
+        from src.db.exceptions import InstrumentMappingError
+
+        (tmp_path / "B").mkdir()
+        _write_daily_csv(tmp_path / "B" / "BAD.txt", "2025-02-01")
+        mock_metadata_service.get_instrument_sync.return_value = _fresh_instrument_row()
+        mock_instrument_mapper.resolve_instrument_id.side_effect = InstrumentMappingError("boom")
+
+        with (
+            patch("src.services.firstrate.import_service.get_parser") as mock_get_parser,
+            patch("src.services.firstrate.import_service.logger") as mock_logger,
+        ):
+            mock_parser = MagicMock()
+            mock_parser.parse_file.return_value = mock_bars
+            mock_get_parser.return_value = mock_parser
+
+            configured_service.import_directory(
+                source_dir=tmp_path,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+
+        progress_calls = [
+            call.kwargs
+            for call in mock_logger.info.call_args_list
+            if call.args and call.args[0] == "import_progress"
+        ]
+        assert len(progress_calls) == 1
+        assert progress_calls[0]["failed"] == 1
+        assert progress_calls[0]["error"] is not None


### PR DESCRIPTION
Implements Story 2.7: structured progress logging + end-of-run summary (tickers processed, rows imported, failures) folding in the Epic 1 `ResolutionSummary`. **Base: feat/story-2.6** (merge after 2.6). One pre-existing Epic-1 edge case deferred to Epic 3 (see `deferred-work.md`).

---
**Stacked PR — merge in order:** #2.4 → #2.5 → #2.6 → #2.7. Built autonomously by the BMAD harness `dev_loop` (run 20260629-185438); verify passed (ruff+mypy+unit+component, traceability unmet=0). No migration, no new deps.