### PR TITLE
Automated: feat/epic3-20260713-233814

### DIFF
--- a/.review_story31.diff
+++ b/.review_story31.diff
@@ -1,0 +1,512 @@
+diff --git a/src/services/firstrate/import_service.py b/src/services/firstrate/import_service.py
+index 75528b3..cbe69ab 100644
+--- a/src/services/firstrate/import_service.py
++++ b/src/services/firstrate/import_service.py
+@@ -27,6 +27,8 @@ from src.services.firstrate.parsers.base import get_parser
+ from src.services.firstrate.source_probe import compute_source_last_date
+ 
+ if TYPE_CHECKING:
++    from nautilus_trader.model.identifiers import InstrumentId
++
+     from src.models.instrument_metadata import InstrumentMetadata
+     from src.services.metadata.instrument_metadata_service import (
+         InstrumentMetadataService,
+@@ -294,8 +296,36 @@ class ImportService:
+                     duration=time.perf_counter() - start,
+                 )
+ 
+-            # 1. Resolve instrument ID
+-            instrument_id = self._instrument_mapper.resolve_instrument_id(ticker, catalog_name)
++            # 1a. Resolve instrument metadata (Story 2.4 AC4). Moved ahead of
++            #     identity resolution (Story 3.1): the qualified venue must be
++            #     known before parsing, because bars are stamped with the
++            #     instrument id and written under {INSTRUMENT_ID}/{BAR_TYPE}/ — a
++            #     later venue change would orphan them. Cache-first, deduped, and
++            #     fault-isolated inside the helper (a metadata hiccup never fails
++            #     an otherwise-good bar import).
++            self._resolve_metadata(ticker)
++
++            # 1b. Qualify (Story 3.1): source the venue from the resolved
++            #     instrument_metadata and sync catalog_instruments.nautilus_id
++            #     (ADR-3). A VENUE_UNRESOLVED ticker returns None — left
++            #     unqualified, no nautilus_id fabricated (AC3). Its exclude/flag/
++            #     keep-bars handling is Story 3.5; here it is skipped this run.
++            instrument_id = self._qualify_ticker(ticker, catalog_name)
++            if instrument_id is None:
++                logger.info(
++                    "ticker_unqualified",
++                    ticker=ticker,
++                    catalog=catalog_name,
++                    timeframe=timeframe,
++                    reason="venue unresolved — deferred to Story 3.5",
++                )
++                return ImportResult(
++                    ticker=ticker,
++                    status="skipped",
++                    row_count=0,
++                    outcome="skipped",
++                    duration=time.perf_counter() - start,
++                )
+ 
+             # 2. Build BarType
+             bar_type = BarType.from_str(f"{instrument_id}-{timeframe}-EXTERNAL")
+@@ -341,16 +371,6 @@ class ImportService:
+                     sample=ohlc_warnings[:3],
+                 )
+ 
+-            # 3b. Resolve instrument metadata (Story 2.4 AC4). Cache-first via
+-            #     the Epic-1 service, which self-upserts into instrument_metadata
+-            #     and skips the provider when the ticker is already RESOLVED.
+-            #     Runs once per parsed ticker per run — deduped inside the helper
+-            #     so the multi-timeframe ETF default does not re-resolve, and the
+-            #     "skipped" short-circuit above means an already-complete re-run
+-            #     resolves nothing. Faults are isolated inside the helper so a
+-            #     metadata hiccup never fails an otherwise-good bar import.
+-            self._resolve_metadata(ticker)
+-
+             # 4. Write to catalog. Delete any existing bars for this exact
+             #    bar_type first so a re-import (or an orphan-heal where the
+             #    metadata row was lost but the Parquet partition survived)
+@@ -715,6 +735,31 @@ class ImportService:
+             and a.volume == b.volume
+         )
+ 
++    def _qualify_ticker(self, ticker: str, catalog_name: str) -> "InstrumentId | None":
++        """Resolve a ticker's Nautilus identity, venue-qualified from metadata (Story 3.1).
++
++        When the Epic-1 resolver ran and captured domain metadata for this ticker, the
++        authoritative resolved ``venue`` drives the qualification: :meth:`InstrumentMapper.
++        sync_qualification` writes ``catalog_instruments.nautilus_id``/``exchange`` (ADR-3)
++        and returns the qualified ``InstrumentId`` — or ``None`` when the venue is
++        ``VENUE_UNRESOLVED`` (``venue is None``), leaving the ticker unqualified (AC3).
++
++        When no resolver is injected (the Phase-1 stocks path / FMP unconfigured) or a
++        provider fault left nothing captured, this falls back to the existing DB identity
++        lookup (:meth:`InstrumentMapper.resolve_instrument_id`) — unchanged behavior (AC4).
++
++        Args:
++            ticker: Trading symbol.
++            catalog_name: Catalog scoping the identity row.
++
++        Returns:
++            The (venue-qualified) ``InstrumentId``, or ``None`` when the venue is unresolved.
++        """
++        metadata = self._resolved_metadata.get(ticker)
++        if self._metadata_resolver is None or metadata is None:
++            return self._instrument_mapper.resolve_instrument_id(ticker, catalog_name)
++        return self._instrument_mapper.sync_qualification(ticker, catalog_name, metadata.venue)
++
+     def _resolve_metadata(self, ticker: str) -> None:
+         """Resolve a parsed ticker's instrument metadata cache-first (Story 2.4).
+ 
+diff --git a/src/services/firstrate/instrument_mapper.py b/src/services/firstrate/instrument_mapper.py
+index efe8912..356832f 100644
+--- a/src/services/firstrate/instrument_mapper.py
++++ b/src/services/firstrate/instrument_mapper.py
+@@ -117,6 +117,70 @@ class InstrumentMapper:
+         )
+         return count
+ 
++    @staticmethod
++    def qualified_instrument_id(ticker: str, venue: Optional[str]) -> Optional[InstrumentId]:
++        """Compute a Nautilus-qualified ``InstrumentId`` from a resolved venue (Story 3.1).
++
++        Pure: the venue is the authoritative code resolved by ``InstrumentMetadataService``
++        (Epic 1) — never a guessed/CSV value. A falsy venue (``None`` or blank, i.e.
++        ``VENUE_UNRESOLVED``) yields ``None`` so no identity is fabricated (AC3). ``venue``
++        is already guaranteed a real code or ``None`` by the domain model's
++        ``venue_never_na_sentinel`` validator, so the ``NA_SENTINEL`` is not re-checked here.
++
++        Args:
++            ticker: Trading symbol (e.g. "SPY").
++            venue: Resolved Nautilus venue code (e.g. "ARCA"), or ``None``/blank.
++
++        Returns:
++            ``InstrumentId`` (e.g. ``SPY.ARCA``), or ``None`` when the venue is unresolved.
++        """
++        if not venue:
++            return None
++        return InstrumentId.from_str(f"{ticker}.{venue}")
++
++    def sync_qualification(
++        self, ticker: str, catalog_name: str, venue: Optional[str]
++    ) -> Optional[InstrumentId]:
++        """Sync the resolved venue onto ``catalog_instruments`` (ADR-3 qualification sync).
++
++        The import pipeline (single writer) calls this after resolving a ticker's metadata:
++        the authoritative resolved ``venue`` overwrites the provisional CSV exchange on the
++        ``catalog_instruments`` identity row and recomputes ``nautilus_id``. ``instrument_metadata``
++        stays the source of truth for resolved metadata; ``catalog_instruments`` for bar
++        counts/date ranges. A ``VENUE_UNRESOLVED`` ticker (``venue is None``) leaves
++        ``nautilus_id`` ``None`` — unqualified, not fabricated (AC3; excludes/flag are Story 3.5).
++
++        Args:
++            ticker: Trading symbol.
++            catalog_name: Catalog scoping the identity row.
++            venue: Resolved Nautilus venue code, or ``None`` when unresolved.
++
++        Returns:
++            The qualified ``InstrumentId``, or ``None`` when the venue is unresolved or no
++            ``catalog_instruments`` row exists (profiles not loaded).
++        """
++        instrument = self._repo.get_by_ticker(catalog_name, ticker)
++        if instrument is None:
++            logger.warning(
++                "qualification_sync_skipped",
++                ticker=ticker,
++                catalog=catalog_name,
++                reason="no catalog_instruments row — company profiles not loaded?",
++            )
++            return None
++
++        qid = self.qualified_instrument_id(ticker, venue)
++        instrument.nautilus_id = str(qid) if qid is not None else None
++        instrument.exchange = venue
++        self._repo.upsert(instrument)
++        logger.debug(
++            "qualification_synced",
++            ticker=ticker,
++            venue=venue,
++            nautilus_id=instrument.nautilus_id,
++        )
++        return qid
++
+     def resolve_instrument_id(self, ticker: str, catalog_name: str) -> InstrumentId:
+         """Look up ticker in DB and return Nautilus InstrumentId.
+ 
+diff --git a/tests/component/services/firstrate/test_import_service.py b/tests/component/services/firstrate/test_import_service.py
+index 47d7119..1cfbb4f 100644
+--- a/tests/component/services/firstrate/test_import_service.py
++++ b/tests/component/services/firstrate/test_import_service.py
+@@ -540,6 +540,10 @@ class TestIdempotentRerun:
+             aapl_row.date_range_end = stateful_metadata_service._datetime(
+                 2024, 12, 31, tzinfo=stateful_metadata_service._tz
+             )
++            # The per-timeframe classifier (commit d75a409) compares the
++            # timeframe's own date_range_end_daily, not the shared
++            # date_range_end — rewind that too so AAPL is genuinely incomplete.
++            aapl_row.date_range_end_daily = aapl_row.date_range_end
+             aapl_row.bar_count_daily = 5
+ 
+             # SPY stays "complete" and must be skipped on re-run; its
+@@ -1175,6 +1179,10 @@ class TestStory26IdempotentRerun:
+             aapl_row.date_range_end = stateful_metadata_service._datetime(
+                 2024, 12, 31, tzinfo=stateful_metadata_service._tz
+             )
++            # The per-timeframe classifier (commit d75a409) compares the
++            # timeframe's own date_range_end_daily, not the shared
++            # date_range_end — rewind that too so AAPL is genuinely incomplete.
++            aapl_row.date_range_end_daily = aapl_row.date_range_end
+             aapl_row.bar_count_daily = 5
+ 
+             writes_before_rerun = mock_catalog.write_data.call_count
+@@ -1228,6 +1236,10 @@ class TestStory26IdempotentRerun:
+             aapl_row.date_range_end = stateful_metadata_service._datetime(
+                 2024, 12, 31, tzinfo=stateful_metadata_service._tz
+             )
++            # The per-timeframe classifier (commit d75a409) compares the
++            # timeframe's own date_range_end_daily, not the shared
++            # date_range_end — rewind that too so AAPL is genuinely incomplete.
++            aapl_row.date_range_end_daily = aapl_row.date_range_end
+             aapl_row.bar_count_daily = 5
+ 
+             # Run 2: a brand-new service (fresh in-run dedup) sharing the SAME
+diff --git a/tests/component/services/firstrate/test_instrument_mapper.py b/tests/component/services/firstrate/test_instrument_mapper.py
+index 87e033c..a43781e 100644
+--- a/tests/component/services/firstrate/test_instrument_mapper.py
++++ b/tests/component/services/firstrate/test_instrument_mapper.py
+@@ -34,6 +34,11 @@ CREATE TABLE IF NOT EXISTS catalog_instruments (
+     state VARCHAR(100),
+     date_range_start TIMESTAMP,
+     date_range_end TIMESTAMP,
++    date_range_end_daily TIMESTAMP,
++    date_range_end_hourly TIMESTAMP,
++    date_range_end_minute TIMESTAMP,
++    date_range_end_5min TIMESTAMP,
++    date_range_end_30min TIMESTAMP,
+     bar_count_daily INTEGER NOT NULL DEFAULT 0,
+     bar_count_hourly INTEGER NOT NULL DEFAULT 0,
+     bar_count_minute INTEGER NOT NULL DEFAULT 0,
+@@ -167,3 +172,36 @@ class TestInstrumentMapperDBRoundTrip:
+         for ticker, expected_id in expected.items():
+             result = mapper.resolve_instrument_id(ticker, CATALOG_NAME)
+             assert result == InstrumentId.from_str(expected_id)
++
++
++class TestQualificationSync:
++    """Story 3.1: ADR-3 qualification sync round-trips through the real repo."""
++
++    @pytest.mark.component
++    def test_sync_overwrites_provisional_exchange_with_resolved_venue(self, mapper, repo, tmp_path):
++        """Resolved venue overwrites the provisional CSV exchange and recomputes id."""
++        # Seed the row with a provisional (wrong) CSV exchange.
++        csv = tmp_path / "profiles.csv"
++        csv.write_text(
++            "SPY,SPDR S&P 500 ETF Trust,US,NY,NYSE,Financial Services,Asset Management,1993-01-22\n"
++        )
++        mapper.load_company_profiles(csv, CATALOG_NAME, ASSET_CLASS)
++        assert repo.get_by_ticker(CATALOG_NAME, "SPY").nautilus_id == "SPY.NYSE"
++
++        result = mapper.sync_qualification("SPY", CATALOG_NAME, "ARCA")
++
++        assert result == InstrumentId.from_str("SPY.ARCA")
++        persisted = repo.get_by_ticker(CATALOG_NAME, "SPY")
++        assert persisted.nautilus_id == "SPY.ARCA"
++        assert persisted.exchange == "ARCA"
++
++    @pytest.mark.component
++    def test_sync_unresolved_persists_null_nautilus_id(self, mapper, repo, company_profiles_csv):
++        """An unresolved (None) venue persists nautilus_id NULL (unqualified, not fabricated)."""
++        mapper.load_company_profiles(company_profiles_csv, CATALOG_NAME, ASSET_CLASS)
++
++        result = mapper.sync_qualification("SPY", CATALOG_NAME, None)
++
++        assert result is None
++        persisted = repo.get_by_ticker(CATALOG_NAME, "SPY")
++        assert persisted.nautilus_id is None
+diff --git a/tests/unit/services/firstrate/test_import_service.py b/tests/unit/services/firstrate/test_import_service.py
+index a3c321d..acec668 100644
+--- a/tests/unit/services/firstrate/test_import_service.py
++++ b/tests/unit/services/firstrate/test_import_service.py
+@@ -1288,6 +1288,158 @@ class TestResolvedMetadataCollection:
+         assert service.resolved_metadata == []
+ 
+ 
++# ---------------------------------------------------------------------------
++# Story 3.1: Venue qualification (nautilus_id from resolved venue + ADR-3 sync)
++# ---------------------------------------------------------------------------
++
++
++def _unresolved_metadata(ticker: str):
++    """Build a VENUE_UNRESOLVED domain InstrumentMetadata (venue None)."""
++    from src.models.instrument_metadata import (
++        InstrumentMetadata,
++        ResolutionStatus,
++    )
++
++    return InstrumentMetadata(
++        ticker=ticker,
++        metadata_provider="FAKE",
++        venue=None,
++        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
++    )
++
++
++@pytest.mark.unit
++class TestVenueQualification:
++    """Story 3.1: identity qualified from the resolved venue, ADR-3 sync."""
++
++    def _service_with_resolver(
++        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
++    ):
++        return ImportService(
++            catalog_manager=mock_catalog_manager,
++            metadata_service=mock_metadata_service,
++            instrument_mapper=mock_instrument_mapper,
++            metadata_resolver=resolver,
++        )
++
++    def test_qualify_ticker_uses_resolved_venue(
++        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
++    ):
++        """A resolved venue drives sync_qualification; resolve_instrument_id unused (AC1/AC2)."""
++        resolver = MagicMock()
++        resolver.resolve.return_value = _domain_metadata("SPY")  # venue "ARCA"
++        qualified = InstrumentId.from_str("SPY.ARCA")
++        mock_instrument_mapper.sync_qualification.return_value = qualified
++        svc = self._service_with_resolver(
++            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
++        )
++
++        svc._resolve_metadata("SPY")
++        result = svc._qualify_ticker("SPY", CATALOG_NAME)
++
++        assert result == qualified
++        mock_instrument_mapper.sync_qualification.assert_called_once_with(
++            "SPY", CATALOG_NAME, "ARCA"
++        )
++        mock_instrument_mapper.resolve_instrument_id.assert_not_called()
++
++    def test_qualify_ticker_unresolved_returns_none(
++        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
++    ):
++        """VENUE_UNRESOLVED venue → sync returns None → ticker left unqualified (AC3)."""
++        resolver = MagicMock()
++        resolver.resolve.return_value = _unresolved_metadata("ZZZ")
++        mock_instrument_mapper.sync_qualification.return_value = None
++        svc = self._service_with_resolver(
++            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
++        )
++
++        svc._resolve_metadata("ZZZ")
++        result = svc._qualify_ticker("ZZZ", CATALOG_NAME)
++
++        assert result is None
++        mock_instrument_mapper.sync_qualification.assert_called_once_with("ZZZ", CATALOG_NAME, None)
++
++    def test_qualify_ticker_no_resolver_falls_back_to_db_lookup(
++        self, service, mock_instrument_mapper
++    ):
++        """No resolver (stocks/unconfigured) → existing DB identity lookup, unchanged (AC4)."""
++        expected = InstrumentId.from_str("AAPL.XNAS")
++        mock_instrument_mapper.resolve_instrument_id.return_value = expected
++
++        result = service._qualify_ticker("AAPL", CATALOG_NAME)
++
++        assert result == expected
++        mock_instrument_mapper.resolve_instrument_id.assert_called_once_with("AAPL", CATALOG_NAME)
++        mock_instrument_mapper.sync_qualification.assert_not_called()
++
++    def test_qualify_ticker_resolver_fault_falls_back(
++        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
++    ):
++        """A provider fault captures nothing → fall back to DB identity (fault-tolerant AC4)."""
++        resolver = MagicMock()
++        resolver.resolve.side_effect = RuntimeError("provider down")
++        expected = InstrumentId.from_str("SPY.ARCA")
++        mock_instrument_mapper.resolve_instrument_id.return_value = expected
++        svc = self._service_with_resolver(
++            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
++        )
++
++        svc._resolve_metadata("SPY")  # fault swallowed, nothing captured
++        result = svc._qualify_ticker("SPY", CATALOG_NAME)
++
++        assert result == expected
++        mock_instrument_mapper.sync_qualification.assert_not_called()
++
++    def test_unqualified_ticker_skips_bar_write(
++        self,
++        mock_catalog_manager,
++        mock_metadata_service,
++        mock_instrument_mapper,
++        mock_bars,
++        tmp_path,
++    ):
++        """End-to-end: an unresolved-venue ticker is skipped — no write_data, logged (AC3)."""
++        resolver = MagicMock()
++        resolver.resolve.return_value = _unresolved_metadata("ZZZ")
++        mock_instrument_mapper.sync_qualification.return_value = None
++        mock_metadata_service.get_instrument_sync.return_value = _fresh_instrument_row()
++
++        mock_catalog = MagicMock()
++        mock_catalog_manager.resolve_catalog.return_value = mock_catalog
++
++        svc = self._service_with_resolver(
++            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
++        )
++
++        (tmp_path / "Z").mkdir()
++        _write_daily_csv(tmp_path / "Z" / "ZZZ.txt", "2025-02-01")
++
++        with (
++            patch("src.services.firstrate.import_service.get_parser") as mock_get_parser,
++            patch("src.services.firstrate.import_service.logger") as mock_logger,
++        ):
++            mock_parser = MagicMock()
++            mock_parser.parse_file.return_value = mock_bars
++            mock_get_parser.return_value = mock_parser
++
++            results = svc.import_directory(
++                source_dir=tmp_path,
++                catalog_name=CATALOG_NAME,
++                asset_class=AssetClass.ETF,
++                timeframe="1-DAY-LAST",
++            )
++
++        assert len(results) == 1
++        assert results[0].status == "skipped"
++        assert results[0].outcome == "skipped"
++        mock_catalog.write_data.assert_not_called()
++        assert any(
++            call.args and call.args[0] == "ticker_unqualified"
++            for call in mock_logger.info.call_args_list
++        )
++
++
+ @pytest.mark.unit
+ class TestImportProgressLogging:
+     """Story 2.7 AC1: per-ticker progress with running counts via structlog."""
+diff --git a/tests/unit/services/firstrate/test_instrument_mapper.py b/tests/unit/services/firstrate/test_instrument_mapper.py
+index dd36ccb..166a53b 100644
+--- a/tests/unit/services/firstrate/test_instrument_mapper.py
++++ b/tests/unit/services/firstrate/test_instrument_mapper.py
+@@ -234,6 +234,78 @@ class TestResolveInstrumentId:
+             mapper.resolve_instrument_id("ZZZZ", CATALOG_NAME)
+ 
+ 
++# ---------------------------------------------------------------------------
++# Story 3.1: Venue qualification (nautilus_id from resolved venue + ADR-3 sync)
++# ---------------------------------------------------------------------------
++
++
++class TestQualification:
++    """Tests for qualified_instrument_id() and sync_qualification()."""
++
++    @pytest.mark.unit
++    def test_qualified_instrument_id_from_venue(self, mapper):
++        """A resolved venue yields a Nautilus-qualified InstrumentId."""
++        assert mapper.qualified_instrument_id("SPY", "ARCA") == InstrumentId.from_str("SPY.ARCA")
++
++    @pytest.mark.unit
++    def test_qualified_instrument_id_none_venue_returns_none(self, mapper):
++        """An unresolved (None) venue fabricates no identity (AC3)."""
++        assert mapper.qualified_instrument_id("SPY", None) is None
++
++    @pytest.mark.unit
++    def test_qualified_instrument_id_blank_venue_returns_none(self, mapper):
++        """A blank venue is treated as unresolved — no identity fabricated."""
++        assert mapper.qualified_instrument_id("SPY", "") is None
++
++    @pytest.mark.unit
++    def test_sync_qualification_writes_nautilus_id_and_exchange(self, mapper, mock_repo):
++        """Resolved venue overwrites the row's nautilus_id/exchange and upserts (ADR-3)."""
++        row = CatalogInstrument(
++            ticker="SPY",
++            nautilus_id="SPY.NYSE",  # provisional CSV exchange
++            exchange="NYSE",
++            asset_class="ETF",
++            catalog_name=CATALOG_NAME,
++        )
++        mock_repo.get_by_ticker.return_value = row
++
++        result = mapper.sync_qualification("SPY", CATALOG_NAME, "ARCA")
++
++        assert result == InstrumentId.from_str("SPY.ARCA")
++        assert row.nautilus_id == "SPY.ARCA"
++        assert row.exchange == "ARCA"
++        mock_repo.upsert.assert_called_once_with(row)
++
++    @pytest.mark.unit
++    def test_sync_qualification_unresolved_leaves_nautilus_id_none(self, mapper, mock_repo):
++        """A None venue leaves nautilus_id None (unqualified, not fabricated — AC3)."""
++        row = CatalogInstrument(
++            ticker="ZZZ",
++            nautilus_id="ZZZ.NYSE",
++            exchange="NYSE",
++            asset_class="ETF",
++            catalog_name=CATALOG_NAME,
++        )
++        mock_repo.get_by_ticker.return_value = row
++
++        result = mapper.sync_qualification("ZZZ", CATALOG_NAME, None)
++
++        assert result is None
++        assert row.nautilus_id is None
++        assert row.exchange is None
++        mock_repo.upsert.assert_called_once_with(row)
++
++    @pytest.mark.unit
++    def test_sync_qualification_missing_row_returns_none_no_upsert(self, mapper, mock_repo):
++        """No catalog_instruments row → defensive no-op (returns None, no upsert)."""
++        mock_repo.get_by_ticker.return_value = None
++
++        result = mapper.sync_qualification("SPY", CATALOG_NAME, "ARCA")
++
++        assert result is None
++        mock_repo.upsert.assert_not_called()
++
++
+ # ---------------------------------------------------------------------------
+ # Task 2: is_loaded Tests
+ # ---------------------------------------------------------------------------

--- a/.story32_review.diff
+++ b/.story32_review.diff
@@ -1,0 +1,402 @@
+diff --git a/src/cli/commands/metadata.py b/src/cli/commands/metadata.py
+new file mode 100644
+index 0000000..3dabc03
+--- /dev/null
++++ b/src/cli/commands/metadata.py
+@@ -0,0 +1,61 @@
++"""CLI commands for instrument metadata inspection (Story 3.2+).
++
++Read-only reports over the local ``instrument_metadata`` cache table. No network
++or provider call — the resolved metadata is produced by the Epic-1 resolution
++service and the Story 3.1 import qualification.
++"""
++
++import click
++from rich.console import Console
++from rich.table import Table
++
++from src.db.exceptions import DatabaseConnectionError
++from src.db.models.instrument_metadata import InstrumentMetadata
++from src.db.repositories.instrument_metadata_repository_sync import (
++    SyncInstrumentMetadataRepository,
++)
++from src.db.session_sync import get_sync_session
++from src.models.instrument_metadata import ResolutionStatus
++from src.services.metadata.unresolved_report import unresolved_reason
++
++console = Console()
++
++
++@click.group()
++def metadata() -> None:
++    """Instrument metadata inspection commands."""
++
++
++@metadata.command("unresolved")
++def unresolved() -> None:
++    """List every ticker whose venue is unresolved (VENUE_UNRESOLVED).
++
++    A worklist for driving the ETF universe to 100% venue coverage — each row
++    carries a derived reason and is the basis for filling in venue_overrides.csv
++    (Story 3.3).
++    """
++    try:
++        with get_sync_session() as session:
++            rows = SyncInstrumentMetadataRepository(session).list_by_status(
++                ResolutionStatus.VENUE_UNRESOLVED
++            )
++    except (RuntimeError, DatabaseConnectionError) as exc:
++        console.print(f"[yellow]Metadata DB not available — {exc}[/yellow]")
++        return
++    _render_unresolved(rows)
++
++
++def _render_unresolved(rows: list[InstrumentMetadata]) -> None:
++    """Render the unresolved-venue rows as a Rich table (or an all-clear line)."""
++    if not rows:
++        console.print("[green]✓ All venues resolved — no unresolved-venue tickers.[/green]")
++        return
++    table = Table(title="Unresolved-venue tickers")
++    table.add_column("Ticker", style="cyan")
++    table.add_column("Provider")
++    table.add_column("Reason")
++    for row in rows:
++        table.add_row(row.ticker, row.metadata_provider, unresolved_reason(row))
++    console.print(table)
++    console.print(f"{len(rows)} ticker(s) with unresolved venue")
++    console.print("Add the correct venue for each in venue_overrides.csv (Story 3.3) to resolve.")
+diff --git a/src/cli/main.py b/src/cli/main.py
+index f296f1c..eca9876 100644
+--- a/src/cli/main.py
++++ b/src/cli/main.py
+@@ -7,6 +7,7 @@ from src.cli.commands.backtest import backtest  # noqa: E402
+ from src.cli.commands.data import data  # noqa: E402
+ from src.cli.commands.history import list_backtest_history  # noqa: E402
+ from src.cli.commands.import_data import import_firstrate  # noqa: E402
++from src.cli.commands.metadata import metadata  # noqa: E402
+ from src.cli.commands.report import report  # noqa: E402
+ from src.cli.commands.run import run_simple  # noqa: E402
+ from src.cli.commands.strategy import strategy  # noqa: E402
+@@ -40,6 +41,7 @@ cli.add_command(strategy)
+ cli.add_command(report)
+ cli.add_command(list_backtest_history)
+ cli.add_command(import_firstrate, "import")
++cli.add_command(metadata)
+ 
+ 
+ if __name__ == "__main__":
+diff --git a/src/db/repositories/instrument_metadata_repository_sync.py b/src/db/repositories/instrument_metadata_repository_sync.py
+index c0ec75a..60f55ce 100644
+--- a/src/db/repositories/instrument_metadata_repository_sync.py
++++ b/src/db/repositories/instrument_metadata_repository_sync.py
+@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
+ 
+ from src.db.exceptions import DatabaseConnectionError, DuplicateRecordError
+ from src.db.models.instrument_metadata import InstrumentMetadata
++from src.models.instrument_metadata import ResolutionStatus
+ 
+ 
+ class SyncInstrumentMetadataRepository:
+@@ -81,3 +82,22 @@ class SyncInstrumentMetadataRepository:
+         stmt = select(InstrumentMetadata).where(InstrumentMetadata.ticker == ticker)
+         result = self.session.execute(stmt)
+         return result.scalar_one_or_none()
++
++    def list_by_status(self, status: ResolutionStatus) -> list[InstrumentMetadata]:
++        """List all metadata rows with the given resolution status, ordered by ticker.
++
++        Served by the ``ix_instrument_metadata_resolution_status`` index. Used by
++        the Story 3.2 unresolved-venue report (``VENUE_UNRESOLVED``).
++
++        Args:
++            status: The resolution status to filter on.
++
++        Returns:
++            Metadata rows matching ``status``, ordered by ticker ascending.
++        """
++        stmt = (
++            select(InstrumentMetadata)
++            .where(InstrumentMetadata.resolution_status == status)
++            .order_by(InstrumentMetadata.ticker)
++        )
++        return list(self.session.execute(stmt).scalars().all())
+diff --git a/src/services/metadata/unresolved_report.py b/src/services/metadata/unresolved_report.py
+new file mode 100644
+index 0000000..0d014f1
+--- /dev/null
++++ b/src/services/metadata/unresolved_report.py
+@@ -0,0 +1,32 @@
++"""Derivation for the Story 3.2 unresolved-venue report.
++
++Pure, side-effect-free classification of *why* a ``VENUE_UNRESOLVED`` row lacks
++a venue, derived from the persisted ``instrument_metadata`` row alone. The raw
++FMP ``exchange`` label is never stored (``normalize_venue`` collapses blank,
++ambiguous, and unmapped labels all to ``venue=None``), so the reason is a
++deliberately best-effort two-way classification — see the module docstring in
++``providers/fmp_provider.py`` for the two paths this discriminates.
++"""
++
++from src.db.models.instrument_metadata import InstrumentMetadata
++
++
++def unresolved_reason(md: InstrumentMetadata) -> str:
++    """Return a human-readable reason a ticker's venue is unresolved.
++
++    Discriminates the FMP provider's two ``VENUE_UNRESOLVED`` paths using
++    ``asset_type``: ``_degraded`` (unknown ticker / no profile) leaves it
++    ``None``, while ``_to_domain`` (profile found, exchange label blank or
++    ambiguous) always assigns a concrete ``AssetType``.
++
++    Args:
++        md: A persisted ``VENUE_UNRESOLVED`` metadata row.
++
++    Returns:
++        A best-effort reason string, provider-agnostic via
++        ``md.metadata_provider``.
++    """
++    provider = md.metadata_provider
++    if md.asset_type is None:
++        return f"unknown to {provider} — no profile returned"
++    return f"{provider} venue label blank, ambiguous (e.g. AMEX), or unmapped"
+diff --git a/tests/component/db/test_instrument_metadata_repository.py b/tests/component/db/test_instrument_metadata_repository.py
+index 2fed1c3..8aea592 100644
+--- a/tests/component/db/test_instrument_metadata_repository.py
++++ b/tests/component/db/test_instrument_metadata_repository.py
+@@ -232,3 +232,48 @@ class TestSyncInstrumentMetadataRepository:
+         result = repo.get_by_ticker("SPY")
+         assert result is not None
+         assert result.resolution_status == ResolutionStatus.UNRESOLVED
++
++    def test_list_by_status_filters_and_orders(self, sync_session):
++        """list_by_status returns only matching rows, ordered by ticker (Story 3.2)."""
++        repo = SyncInstrumentMetadataRepository(sync_session)
++        repo.upsert(
++            InstrumentMetadata(
++                **_make_metadata(ticker="AAA", resolution_status=ResolutionStatus.RESOLVED)
++            )
++        )
++        repo.upsert(
++            InstrumentMetadata(
++                **_make_metadata(
++                    ticker="CCC", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
++                )
++            )
++        )
++        repo.upsert(
++            InstrumentMetadata(
++                **_make_metadata(
++                    ticker="BBB", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
++                )
++            )
++        )
++        repo.upsert(
++            InstrumentMetadata(
++                **_make_metadata(ticker="DDD", resolution_status=ResolutionStatus.UNRESOLVED)
++            )
++        )
++        sync_session.commit()
++
++        rows = repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED)
++
++        assert [r.ticker for r in rows] == ["BBB", "CCC"]
++
++    def test_list_by_status_empty_returns_empty_list(self, sync_session):
++        """list_by_status returns [] when no rows match the status."""
++        repo = SyncInstrumentMetadataRepository(sync_session)
++        repo.upsert(
++            InstrumentMetadata(
++                **_make_metadata(ticker="AAA", resolution_status=ResolutionStatus.RESOLVED)
++            )
++        )
++        sync_session.commit()
++
++        assert repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED) == []
+diff --git a/tests/unit/cli/commands/test_metadata.py b/tests/unit/cli/commands/test_metadata.py
+new file mode 100644
+index 0000000..2f2d7c2
+--- /dev/null
++++ b/tests/unit/cli/commands/test_metadata.py
+@@ -0,0 +1,117 @@
++"""Unit tests for the `metadata` CLI group (Story 3.2 unresolved-venue report)."""
++
++from unittest.mock import MagicMock, patch
++
++import pytest
++from click.testing import CliRunner
++
++from src.cli.commands.metadata import _render_unresolved, metadata
++from src.db.models.instrument_metadata import InstrumentMetadata
++from src.models.instrument_metadata import NA_SENTINEL, AssetType, ResolutionStatus
++
++
++@pytest.fixture
++def runner():
++    return CliRunner()
++
++
++def _degraded_row(ticker: str) -> InstrumentMetadata:
++    return InstrumentMetadata(
++        ticker=ticker,
++        metadata_provider="FMP",
++        venue=None,
++        asset_type=None,
++        company_name=NA_SENTINEL,
++        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
++    )
++
++
++def _found_row(ticker: str) -> InstrumentMetadata:
++    return InstrumentMetadata(
++        ticker=ticker,
++        metadata_provider="FMP",
++        venue=None,
++        asset_type=AssetType.ETF.value,
++        company_name="Example ETF",
++        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
++    )
++
++
++def _patch_session_and_repo():
++    """Return (session, repo) patchers backed by a fake sync session."""
++    ctx = MagicMock()
++    ctx.__enter__.return_value = MagicMock()
++    ctx.__exit__.return_value = False
++    session_patch = patch("src.cli.commands.metadata.get_sync_session", return_value=ctx)
++    repo_patch = patch("src.cli.commands.metadata.SyncInstrumentMetadataRepository")
++    return session_patch, repo_patch
++
++
++@pytest.mark.unit
++class TestMetadataUnresolved:
++    """`metadata unresolved` CLI subcommand."""
++
++    def test_populated_lists_tickers_reasons_and_hint(self, runner):
++        rows = [_degraded_row("ZZZ"), _found_row("SPY")]
++        session_patch, repo_patch = _patch_session_and_repo()
++        with session_patch, repo_patch as mock_repo:
++            mock_repo.return_value.list_by_status.return_value = rows
++            result = runner.invoke(metadata, ["unresolved"])
++
++        assert result.exit_code == 0
++        assert "ZZZ" in result.output
++        assert "SPY" in result.output
++        assert "unknown to FMP" in result.output
++        assert "ambiguous" in result.output
++        assert "2 ticker" in result.output
++        assert "venue_overrides.csv" in result.output
++
++    def test_empty_prints_all_resolved_message(self, runner):
++        session_patch, repo_patch = _patch_session_and_repo()
++        with session_patch, repo_patch as mock_repo:
++            mock_repo.return_value.list_by_status.return_value = []
++            result = runner.invoke(metadata, ["unresolved"])
++
++        assert result.exit_code == 0
++        assert "All venues resolved" in result.output
++        assert "Ticker" not in result.output  # no table header rendered
++
++    def test_db_unconfigured_degrades_gracefully(self, runner):
++        ctx = MagicMock()
++        ctx.__enter__.side_effect = RuntimeError(
++            "Database not configured. Check DATABASE_URL in .env file"
++        )
++        with patch("src.cli.commands.metadata.get_sync_session", return_value=ctx):
++            result = runner.invoke(metadata, ["unresolved"])
++
++        assert result.exit_code == 0
++        assert result.exception is None
++        assert "not" in result.output.lower()  # a clear warning, no traceback
++
++
++@pytest.mark.unit
++class TestRegistration:
++    """The `metadata` group is wired into the top-level CLI."""
++
++    def test_metadata_group_registered_with_unresolved(self):
++        from src.cli.main import cli
++
++        assert "metadata" in cli.commands
++        assert "unresolved" in cli.commands["metadata"].commands
++
++
++@pytest.mark.unit
++class TestRenderUnresolved:
++    """Direct render-helper tests (no CliRunner)."""
++
++    def test_render_orders_rows_and_shows_reasons(self, capsys):
++        _render_unresolved([_found_row("SPY"), _degraded_row("ZZZ")])
++        out = capsys.readouterr().out
++        assert "SPY" in out and "ZZZ" in out
++        assert "unknown to FMP" in out
++        assert "unmapped" in out
++
++    def test_render_empty(self, capsys):
++        _render_unresolved([])
++        out = capsys.readouterr().out
++        assert "All venues resolved" in out
+diff --git a/tests/unit/services/metadata/test_unresolved_report.py b/tests/unit/services/metadata/test_unresolved_report.py
+new file mode 100644
+index 0000000..e0b2532
+--- /dev/null
++++ b/tests/unit/services/metadata/test_unresolved_report.py
+@@ -0,0 +1,60 @@
++"""Unit tests for the Story 3.2 unresolved-venue reason derivation."""
++
++import pytest
++
++from src.db.models.instrument_metadata import InstrumentMetadata
++from src.models.instrument_metadata import NA_SENTINEL, AssetType, ResolutionStatus
++from src.services.metadata.unresolved_report import unresolved_reason
++
++
++def _degraded_row(ticker: str = "ZZZ", provider: str = "FMP") -> InstrumentMetadata:
++    """An ORM row shaped like the FMP provider's `_degraded` output (unknown ticker)."""
++    return InstrumentMetadata(
++        ticker=ticker,
++        metadata_provider=provider,
++        venue=None,
++        currency=NA_SENTINEL,
++        asset_type=None,
++        company_name=NA_SENTINEL,
++        sector=NA_SENTINEL,
++        industry=NA_SENTINEL,
++        country=NA_SENTINEL,
++        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
++    )
++
++
++def _found_unmapped_row(ticker: str = "SPY", provider: str = "FMP") -> InstrumentMetadata:
++    """An ORM row shaped like `_to_domain` with a blank/ambiguous exchange label."""
++    return InstrumentMetadata(
++        ticker=ticker,
++        metadata_provider=provider,
++        venue=None,
++        currency="USD",
++        asset_type=AssetType.ETF.value,
++        company_name="SPDR S&P 500 ETF Trust",
++        sector=NA_SENTINEL,
++        industry=NA_SENTINEL,
++        country="US",
++        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
++    )
++
++
++@pytest.mark.unit
++class TestUnresolvedReason:
++    """Derive a human-readable reason for a VENUE_UNRESOLVED row."""
++
++    def test_degraded_row_is_unknown_to_provider(self):
++        reason = unresolved_reason(_degraded_row())
++        assert "unknown to FMP" in reason
++        assert "no profile" in reason.lower()
++
++    def test_found_but_unmapped_row_is_label_unusable(self):
++        reason = unresolved_reason(_found_unmapped_row())
++        assert "unknown to" not in reason.lower()
++        assert "ambiguous" in reason.lower()
++        assert "unmapped" in reason.lower()
++
++    def test_reason_is_provider_agnostic(self):
++        reason = unresolved_reason(_degraded_row(provider="OTHER"))
++        assert "OTHER" in reason
++        assert "FMP" not in reason

--- a/.story33_review.diff
+++ b/.story33_review.diff
@@ -1,0 +1,699 @@
+diff --git a/src/cli/commands/import_data.py b/src/cli/commands/import_data.py
+index 4fbf124..b37f7ec 100644
+--- a/src/cli/commands/import_data.py
++++ b/src/cli/commands/import_data.py
+@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
+ from src.api.models.explorer import ExplorerTimeframe
+ 
+ if TYPE_CHECKING:
+-    from src.config import FMPSettings
++    from src.config import FMPSettings, Settings
+     from src.services.metadata.instrument_metadata_service import (
+         InstrumentMetadataService,
+     )
+@@ -155,6 +155,49 @@ def _build_metadata_resolver(
+     return InstrumentMetadataService(provider=provider, repository=repository)
+ 
+ 
++def _apply_venue_overrides(session: Session, settings: "Settings") -> None:
++    """Merge venue_overrides.csv into the metadata store during import (Story 3.3).
++
++    Thin orchestration helper: load the CSV (path via config), and if it carries
++    any corrections, merge them with precedence into ``instrument_metadata`` on
++    the open session (committed by the caller). A header-only/absent file is a
++    silent no-op; a malformed header degrades to a single warning without
++    aborting the in-flight import (bars already imported are preserved).
++
++    Args:
++        session: Open sync DB session (shares the import transaction).
++        settings: Application settings (provides the override path).
++    """
++    from datetime import datetime, timezone
++
++    from src.db.repositories.instrument_metadata_repository_sync import (
++        SyncInstrumentMetadataRepository,
++    )
++    from src.services.metadata.venue_overrides import (
++        VenueOverrideError,
++        load_venue_overrides,
++        merge_venue_overrides,
++    )
++
++    path = Path(settings.firstrate.firstrate_venue_overrides_path)
++    try:
++        overrides = load_venue_overrides(path)
++    except VenueOverrideError as exc:
++        console.print(f"[yellow]Venue overrides not applied — {exc}[/yellow]")
++        return
++    if not overrides:
++        return
++    result = merge_venue_overrides(
++        overrides,
++        SyncInstrumentMetadataRepository(session),
++        datetime.now(timezone.utc),
++    )
++    console.print(
++        f"Venue overrides: {result.applied} applied, "
++        f"{result.unchanged} unchanged, {len(result.unmatched)} unmatched"
++    )
++
++
+ def _find_profiles_csv(source_path: Path) -> Path | None:
+     """Locate the FirstRate company_profiles.csv for a given import source.
+ 
+@@ -357,6 +400,12 @@ def _run_import(
+ 
+             all_results.extend(results)
+ 
++        # Story 3.3: merge manual venue corrections (venue_overrides.csv) into the
++        # metadata store with precedence — runs in the import-orchestration step
++        # (not FMPClient), after the FMP-resolved rows are written and before the
++        # single commit, so overrides win over absent/ambiguous provider venues.
++        _apply_venue_overrides(session, settings)
++
+         # Commit all profile loads and metadata upserts as a single transaction.
+         session.commit()
+ 
+diff --git a/src/cli/commands/metadata.py b/src/cli/commands/metadata.py
+index 385e822..9926174 100644
+--- a/src/cli/commands/metadata.py
++++ b/src/cli/commands/metadata.py
+@@ -5,12 +5,16 @@ or provider call — the resolved metadata is produced by the Epic-1 resolution
+ service and the Story 3.1 import qualification.
+ """
+ 
++from datetime import datetime, timezone
++from pathlib import Path
++
+ import click
+ from rich.console import Console
+ from rich.markup import escape
+ from rich.table import Table
+ from sqlalchemy.exc import SQLAlchemyError
+ 
++from src.config import get_settings
+ from src.db.exceptions import DatabaseConnectionError
+ from src.db.models.instrument_metadata import InstrumentMetadata
+ from src.db.repositories.instrument_metadata_repository_sync import (
+@@ -19,6 +23,12 @@ from src.db.repositories.instrument_metadata_repository_sync import (
+ from src.db.session_sync import get_sync_session
+ from src.models.instrument_metadata import ResolutionStatus
+ from src.services.metadata.unresolved_report import unresolved_reason
++from src.services.metadata.venue_overrides import (
++    VenueOverrideError,
++    VenueOverrideMergeResult,
++    load_venue_overrides,
++    merge_venue_overrides,
++)
+ 
+ console = Console()
+ 
+@@ -65,3 +75,47 @@ def _render_unresolved(rows: list[InstrumentMetadata]) -> None:
+     console.print(table)
+     console.print(f"{len(rows)} ticker(s) with unresolved venue")
+     console.print("Add the correct venue for each in venue_overrides.csv (Story 3.3) to resolve.")
++
++
++@metadata.command("apply-overrides")
++def apply_overrides() -> None:
++    """Merge venue_overrides.csv into the metadata store, with precedence (Story 3.3).
++
++    The metadata-refresh path: fill the CSV from the ``metadata unresolved``
++    worklist, then apply the corrections without re-importing bars. Each override
++    flips a matching row to RESOLVED; re-running is idempotent.
++    """
++    path = Path(get_settings().firstrate.firstrate_venue_overrides_path)
++    try:
++        overrides = load_venue_overrides(path)
++    except VenueOverrideError as exc:
++        console.print(f"[yellow]Venue overrides not applied — {escape(str(exc))}[/yellow]")
++        return
++    if not overrides:
++        console.print(
++            f"[green]✓ No venue overrides to apply ({escape(str(path))} is empty/absent).[/green]"
++        )
++        return
++    try:
++        with get_sync_session() as session:
++            result = merge_venue_overrides(
++                overrides,
++                SyncInstrumentMetadataRepository(session),
++                datetime.now(timezone.utc),
++            )
++            session.commit()
++    except (RuntimeError, DatabaseConnectionError, SQLAlchemyError) as exc:
++        console.print(f"[yellow]Metadata DB not available — {escape(str(exc))}[/yellow]")
++        return
++    _render_override_summary(result)
++
++
++def _render_override_summary(result: VenueOverrideMergeResult) -> None:
++    """Print a one-line venue-override merge summary (+ unmatched tickers, if any)."""
++    console.print(
++        f"Venue overrides: {result.applied} applied, "
++        f"{result.unchanged} unchanged, {len(result.unmatched)} unmatched"
++    )
++    if result.unmatched:
++        joined = ", ".join(escape(t) for t in result.unmatched)
++        console.print(f"[yellow]Unmatched (no metadata row): {joined}[/yellow]")
+diff --git a/src/config.py b/src/config.py
+index 12bb0a5..37a5b03 100644
+--- a/src/config.py
++++ b/src/config.py
+@@ -154,6 +154,10 @@ class FirstRateSettings(BaseSettings):
+         default="firstrate-etf",
+         description="Default catalog name for FirstRate imports",
+     )
++    firstrate_venue_overrides_path: str = Field(
++        default="venue_overrides.csv",
++        description="Path to the git-tracked venue overrides CSV (header: ticker,venue)",
++    )
+ 
+     model_config = {
+         "env_file": ".env",
+diff --git a/src/db/repositories/instrument_metadata_repository_sync.py b/src/db/repositories/instrument_metadata_repository_sync.py
+index fc3e03b..2aab1db 100644
+--- a/src/db/repositories/instrument_metadata_repository_sync.py
++++ b/src/db/repositories/instrument_metadata_repository_sync.py
+@@ -8,6 +8,7 @@ Operates on the SQLAlchemy ORM ``InstrumentMetadata``
+ same name. ORM↔domain mapping is the Story 1.5 service's responsibility.
+ """
+ 
++from datetime import datetime
+ from typing import Optional
+ 
+ from sqlalchemy import select
+@@ -108,3 +109,39 @@ class SyncInstrumentMetadataRepository:
+             return list(self.session.execute(stmt).scalars().all())
+         except OperationalError as e:
+             raise DatabaseConnectionError(f"Database connection failed: {e}") from e
++
++    def apply_venue_override(self, ticker: str, venue: str, resolved_at: datetime) -> str:
++        """Apply a manual venue override to an existing row, with precedence (Story 3.3).
++
++        Sets ``venue`` and forces ``resolution_status = RESOLVED`` (the operator's
++        correction wins over absent/ambiguous provider data). Idempotent: a row
++        already at the override target (``venue`` matches and status ``RESOLVED``)
++        is left untouched — no write, no ``resolved_at`` churn. A ticker with no
++        row is reported ``"unmatched"`` (never fabricated). Descriptive fields are
++        never touched.
++
++        Args:
++            ticker: Ticker to correct (must already exist in the store).
++            venue: Operator-supplied Nautilus venue code.
++            resolved_at: Timestamp stamped on a row this call changes.
++
++        Returns:
++            One of ``"applied"`` (row changed), ``"unchanged"`` (already at
++            target), or ``"unmatched"`` (no such row).
++
++        Raises:
++            DatabaseConnectionError: If the query/flush fails (mirrors ``upsert``).
++        """
++        try:
++            row = self.get_by_ticker(ticker)
++            if row is None:
++                return "unmatched"
++            if row.venue == venue and row.resolution_status == ResolutionStatus.RESOLVED:
++                return "unchanged"
++            row.venue = venue
++            row.resolution_status = ResolutionStatus.RESOLVED
++            row.resolved_at = resolved_at
++            self.session.flush()
++            return "applied"
++        except OperationalError as e:
++            raise DatabaseConnectionError(f"Database connection failed: {e}") from e
+diff --git a/src/services/metadata/venue_overrides.py b/src/services/metadata/venue_overrides.py
+new file mode 100644
+index 0000000..dd8d6b4
+--- /dev/null
++++ b/src/services/metadata/venue_overrides.py
+@@ -0,0 +1,132 @@
++"""Manual venue corrections: load ``venue_overrides.csv`` and merge with precedence (Story 3.3).
++
++The operator supplies venues the conservative FMP map (ADR-6) could not resolve
++in a git-tracked ``venue_overrides.csv`` (header exactly ``ticker,venue``). This
++module owns the pure CSV parse (``load_venue_overrides``) and the store-merge
++orchestration (``merge_venue_overrides``) that flips matching rows to
++``RESOLVED`` with the override venue taking precedence.
++
++The merge is an import-orchestration concern layered over the persisted metadata
++rows — it never calls ``FMPClient`` / the provider, and the clock is passed in by
++the caller so unchanged rows stay untouched (idempotent re-runs).
++"""
++
++import csv
++from datetime import datetime
++from pathlib import Path
++
++import structlog
++from pydantic import BaseModel
++
++from src.db.repositories.instrument_metadata_repository_sync import (
++    SyncInstrumentMetadataRepository,
++)
++from src.models.instrument_metadata import NA_SENTINEL
++
++logger = structlog.get_logger(__name__)
++
++#: The exact header the override file must carry (cells compared case-insensitively).
++_EXPECTED_HEADER = ["ticker", "venue"]
++
++
++class VenueOverrideError(Exception):
++    """Raised on a malformed override file (header not exactly ``ticker,venue``)."""
++
++
++class VenueOverrideMergeResult(BaseModel):
++    """Outcome tally for a ``merge_venue_overrides`` run.
++
++    Attributes:
++        applied: Rows whose venue/status were changed by an override.
++        unchanged: Rows already at the override target (idempotent no-write).
++        unmatched: Override tickers with no ``instrument_metadata`` row (surfaced,
++            never fabricated).
++    """
++
++    applied: int = 0
++    unchanged: int = 0
++    unmatched: list[str] = []
++
++    @property
++    def total(self) -> int:
++        """Total overrides processed across all three outcomes."""
++        return self.applied + self.unchanged + len(self.unmatched)
++
++
++def load_venue_overrides(path: Path) -> dict[str, str]:
++    """Parse ``venue_overrides.csv`` into a ``{TICKER: VENUE}`` map (pure).
++
++    A missing file returns ``{}`` (overrides are optional; an absent or
++    header-only file must never break an import). The header row must match
++    ``ticker,venue`` exactly (case/whitespace-insensitive) or ``VenueOverrideError``
++    is raised. Data rows are normalized (ticker/venue upper-cased, trimmed); a row
++    with a blank ticker, blank venue, or a venue equal to ``NA_SENTINEL`` is
++    skipped (an unfilled worklist line is not an error). Duplicate tickers:
++    last wins.
++
++    Args:
++        path: Path to the override CSV.
++
++    Returns:
++        Mapping of normalized ticker to normalized venue code.
++
++    Raises:
++        VenueOverrideError: If the header is not exactly ``ticker,venue``.
++    """
++    if not path.exists():
++        return {}
++
++    overrides: dict[str, str] = {}
++    with path.open(encoding="utf-8-sig", newline="") as handle:
++        reader = csv.reader(handle)
++        header = next(reader, None)
++        if header is None or [c.strip().lower() for c in header] != _EXPECTED_HEADER:
++            raise VenueOverrideError(
++                f"venue_overrides header must be exactly 'ticker,venue' (got: {header!r})"
++            )
++        for row in reader:
++            if len(row) < 2:
++                continue
++            ticker = row[0].strip().upper()
++            venue = row[1].strip().upper()
++            if not ticker or not venue or venue == NA_SENTINEL:
++                logger.debug(
++                    "venue_override_row_skipped", ticker=ticker or None, venue=venue or None
++                )
++                continue
++            if ticker in overrides and overrides[ticker] != venue:
++                logger.warning("venue_override_shadowed", ticker=ticker, kept=venue)
++            overrides[ticker] = venue
++    return overrides
++
++
++def merge_venue_overrides(
++    overrides: dict[str, str],
++    repository: SyncInstrumentMetadataRepository,
++    resolved_at: datetime,
++) -> VenueOverrideMergeResult:
++    """Merge overrides into ``instrument_metadata`` with precedence, tallying outcomes.
++
++    Iterates tickers in sorted order (deterministic) and delegates each to
++    ``repository.apply_venue_override`` (which flips a matching row to ``RESOLVED``
++    or reports ``unchanged``/``unmatched``). The clock is threaded in via
++    ``resolved_at`` — the caller stamps it once so unchanged rows never churn.
++
++    Args:
++        overrides: ``{TICKER: VENUE}`` map from ``load_venue_overrides``.
++        repository: Sync metadata repository backing the store.
++        resolved_at: Timestamp recorded on rows the merge changes.
++
++    Returns:
++        The applied/unchanged/unmatched tally.
++    """
++    result = VenueOverrideMergeResult()
++    for ticker, venue in sorted(overrides.items()):
++        outcome = repository.apply_venue_override(ticker, venue, resolved_at)
++        if outcome == "applied":
++            result.applied += 1
++        elif outcome == "unchanged":
++            result.unchanged += 1
++        else:
++            result.unmatched.append(ticker)
++    return result
+diff --git a/tests/component/db/test_instrument_metadata_repository.py b/tests/component/db/test_instrument_metadata_repository.py
+index 7bd6872..2e5bd57 100644
+--- a/tests/component/db/test_instrument_metadata_repository.py
++++ b/tests/component/db/test_instrument_metadata_repository.py
+@@ -292,3 +292,68 @@ class TestSyncInstrumentMetadataRepository:
+ 
+         with pytest.raises(DatabaseConnectionError):
+             repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED)
++
++    def test_apply_venue_override_flips_unresolved_to_resolved(self, sync_session):
++        """An override sets venue + RESOLVED on an existing VENUE_UNRESOLVED row (Story 3.3)."""
++        from datetime import datetime, timezone
++
++        repo = SyncInstrumentMetadataRepository(sync_session)
++        repo.upsert(
++            InstrumentMetadata(
++                **_make_metadata(
++                    ticker="SPY", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
++                )
++            )
++        )
++        sync_session.commit()
++
++        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
++        outcome = repo.apply_venue_override("SPY", "ARCA", ts)
++        sync_session.commit()
++
++        assert outcome == "applied"
++        row = repo.get_by_ticker("SPY")
++        assert row is not None
++        assert row.venue == "ARCA"
++        assert row.resolution_status == ResolutionStatus.RESOLVED
++        # SQLite's TIMESTAMP column round-trips tz-naive; compare the wall value.
++        assert row.resolved_at == ts.replace(tzinfo=None)
++
++    def test_apply_venue_override_is_idempotent(self, sync_session):
++        """Re-applying the same override is a no-op — no resolved_at churn (AC3)."""
++        from datetime import datetime, timezone
++
++        repo = SyncInstrumentMetadataRepository(sync_session)
++        repo.upsert(
++            InstrumentMetadata(
++                **_make_metadata(
++                    ticker="SPY", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
++                )
++            )
++        )
++        sync_session.commit()
++
++        ts1 = datetime(2026, 7, 13, tzinfo=timezone.utc)
++        repo.apply_venue_override("SPY", "ARCA", ts1)
++        sync_session.commit()
++
++        ts2 = datetime(2026, 7, 14, tzinfo=timezone.utc)
++        outcome = repo.apply_venue_override("SPY", "ARCA", ts2)
++        sync_session.commit()
++
++        assert outcome == "unchanged"
++        row = repo.get_by_ticker("SPY")
++        assert row is not None
++        assert row.resolved_at == ts1.replace(tzinfo=None)  # not overwritten by 2nd call
++
++    def test_apply_venue_override_unmatched_ticker(self, sync_session):
++        """An override for an absent ticker returns 'unmatched' and creates no row."""
++        from datetime import datetime, timezone
++
++        repo = SyncInstrumentMetadataRepository(sync_session)
++        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
++
++        outcome = repo.apply_venue_override("NOPE", "ARCA", ts)
++
++        assert outcome == "unmatched"
++        assert repo.get_by_ticker("NOPE") is None
+diff --git a/tests/unit/cli/commands/test_import_data.py b/tests/unit/cli/commands/test_import_data.py
+index ea97e9f..48369e3 100644
+--- a/tests/unit/cli/commands/test_import_data.py
++++ b/tests/unit/cli/commands/test_import_data.py
+@@ -1011,3 +1011,59 @@ class TestStory17ProgressAndSummary:
+             ),
+         ]
+         assert determine_exit_code(results) == 1
++
++
++# ---------------------------------------------------------------------------
++# Story 3.3: venue-override merge wiring (_apply_venue_overrides)
++# ---------------------------------------------------------------------------
++
++
++@pytest.mark.unit
++class TestApplyVenueOverrides:
++    """The import-orchestration helper that merges venue_overrides.csv."""
++
++    def _settings(self, path: str):
++        from unittest.mock import MagicMock
++
++        settings = MagicMock()
++        settings.firstrate.firstrate_venue_overrides_path = path
++        return settings
++
++    def test_empty_file_is_silent_noop(self, capsys):
++        from src.cli.commands.import_data import _apply_venue_overrides
++
++        with patch("src.services.metadata.venue_overrides.load_venue_overrides", return_value={}):
++            _apply_venue_overrides(object(), self._settings("venue_overrides.csv"))
++        assert "Venue overrides" not in capsys.readouterr().out
++
++    def test_non_empty_prints_summary(self, capsys):
++        from src.cli.commands.import_data import _apply_venue_overrides
++        from src.services.metadata.venue_overrides import VenueOverrideMergeResult
++
++        with (
++            patch(
++                "src.services.metadata.venue_overrides.load_venue_overrides",
++                return_value={"SPY": "ARCA"},
++            ),
++            patch(
++                "src.services.metadata.venue_overrides.merge_venue_overrides",
++                return_value=VenueOverrideMergeResult(applied=1),
++            ),
++            patch(
++                "src.db.repositories.instrument_metadata_repository_sync."
++                "SyncInstrumentMetadataRepository"
++            ),
++        ):
++            _apply_venue_overrides(object(), self._settings("venue_overrides.csv"))
++        assert "1 applied" in capsys.readouterr().out
++
++    def test_malformed_header_warns_and_skips(self, capsys):
++        from src.cli.commands.import_data import _apply_venue_overrides
++        from src.services.metadata.venue_overrides import VenueOverrideError
++
++        with patch(
++            "src.services.metadata.venue_overrides.load_venue_overrides",
++            side_effect=VenueOverrideError("bad header"),
++        ):
++            _apply_venue_overrides(object(), self._settings("venue_overrides.csv"))
++        assert "not applied" in capsys.readouterr().out
+diff --git a/tests/unit/cli/commands/test_metadata.py b/tests/unit/cli/commands/test_metadata.py
+index c51b9c2..1d00ddd 100644
+--- a/tests/unit/cli/commands/test_metadata.py
++++ b/tests/unit/cli/commands/test_metadata.py
+@@ -117,6 +117,79 @@ class TestMetadataUnresolved:
+         assert "Metadata DB not available" in result.output
+ 
+ 
++@pytest.mark.unit
++class TestMetadataApplyOverrides:
++    """`metadata apply-overrides` refresh subcommand (Story 3.3)."""
++
++    def _patch_settings(self, path: str = "venue_overrides.csv"):
++        settings = MagicMock()
++        settings.firstrate.firstrate_venue_overrides_path = path
++        return patch("src.cli.commands.metadata.get_settings", return_value=settings)
++
++    def test_populated_merges_and_prints_summary(self, runner):
++        from src.services.metadata.venue_overrides import VenueOverrideMergeResult
++
++        session_patch, repo_patch = _patch_session_and_repo()
++        with (
++            self._patch_settings(),
++            patch(
++                "src.cli.commands.metadata.load_venue_overrides",
++                return_value={"SPY": "ARCA"},
++            ),
++            patch(
++                "src.cli.commands.metadata.merge_venue_overrides",
++                return_value=VenueOverrideMergeResult(applied=1, unchanged=0, unmatched=["ZZZ"]),
++            ),
++            session_patch,
++            repo_patch,
++        ):
++            result = runner.invoke(metadata, ["apply-overrides"])
++
++        assert result.exit_code == 0
++        assert "1 applied" in result.output
++        assert "ZZZ" in result.output  # unmatched surfaced
++
++    def test_empty_file_is_noop(self, runner):
++        with (
++            self._patch_settings(),
++            patch("src.cli.commands.metadata.load_venue_overrides", return_value={}),
++        ):
++            result = runner.invoke(metadata, ["apply-overrides"])
++
++        assert result.exit_code == 0
++        assert "No venue overrides to apply" in result.output
++
++    def test_malformed_file_degrades_gracefully(self, runner):
++        from src.services.metadata.venue_overrides import VenueOverrideError
++
++        with (
++            self._patch_settings(),
++            patch(
++                "src.cli.commands.metadata.load_venue_overrides",
++                side_effect=VenueOverrideError("header must be exactly 'ticker,venue'"),
++            ),
++        ):
++            result = runner.invoke(metadata, ["apply-overrides"])
++
++        assert result.exit_code == 0
++        assert result.exception is None
++        assert "not applied" in result.output
++
++    def test_db_unconfigured_degrades_gracefully(self, runner):
++        ctx = MagicMock()
++        ctx.__enter__.side_effect = RuntimeError("Database not configured")
++        with (
++            self._patch_settings(),
++            patch("src.cli.commands.metadata.load_venue_overrides", return_value={"SPY": "ARCA"}),
++            patch("src.cli.commands.metadata.get_sync_session", return_value=ctx),
++        ):
++            result = runner.invoke(metadata, ["apply-overrides"])
++
++        assert result.exit_code == 0
++        assert result.exception is None
++        assert "Metadata DB not available" in result.output
++
++
+ @pytest.mark.unit
+ class TestRegistration:
+     """The `metadata` group is wired into the top-level CLI."""
+@@ -126,6 +199,7 @@ class TestRegistration:
+ 
+         assert "metadata" in cli.commands
+         assert "unresolved" in cli.commands["metadata"].commands
++        assert "apply-overrides" in cli.commands["metadata"].commands
+ 
+ 
+ @pytest.mark.unit
+diff --git a/tests/unit/services/metadata/test_venue_overrides.py b/tests/unit/services/metadata/test_venue_overrides.py
+new file mode 100644
+index 0000000..5ce6459
+--- /dev/null
++++ b/tests/unit/services/metadata/test_venue_overrides.py
+@@ -0,0 +1,94 @@
++"""Unit tests for venue_overrides loader + merge core (Story 3.3)."""
++
++from datetime import datetime, timezone
++from unittest.mock import MagicMock
++
++import pytest
++
++from src.services.metadata.venue_overrides import (
++    VenueOverrideError,
++    VenueOverrideMergeResult,
++    load_venue_overrides,
++    merge_venue_overrides,
++)
++
++
++def _write(path, text: str, encoding: str = "utf-8") -> None:
++    path.write_text(text, encoding=encoding)
++
++
++@pytest.mark.unit
++class TestLoadVenueOverrides:
++    """`load_venue_overrides` — pure CSV parse with normalization + skips."""
++
++    def test_valid_file_normalizes_ticker_and_venue(self, tmp_path):
++        f = tmp_path / "venue_overrides.csv"
++        _write(f, "ticker,venue\n spy , arca \nqqq,NASDAQ\n")
++        assert load_venue_overrides(f) == {"SPY": "ARCA", "QQQ": "NASDAQ"}
++
++    def test_missing_file_returns_empty(self, tmp_path):
++        assert load_venue_overrides(tmp_path / "nope.csv") == {}
++
++    def test_header_only_returns_empty(self, tmp_path):
++        f = tmp_path / "venue_overrides.csv"
++        _write(f, "ticker,venue\n")
++        assert load_venue_overrides(f) == {}
++
++    def test_bom_header_is_tolerated(self, tmp_path):
++        f = tmp_path / "venue_overrides.csv"
++        _write(f, "ticker,venue\nSPY,ARCA\n", encoding="utf-8-sig")
++        assert load_venue_overrides(f) == {"SPY": "ARCA"}
++
++    def test_malformed_header_raises(self, tmp_path):
++        f = tmp_path / "venue_overrides.csv"
++        _write(f, "symbol,exchange\nSPY,ARCA\n")
++        with pytest.raises(VenueOverrideError):
++            load_venue_overrides(f)
++
++    def test_blank_ticker_venue_and_na_rows_skipped(self, tmp_path):
++        f = tmp_path / "venue_overrides.csv"
++        _write(f, "ticker,venue\n,ARCA\nSPY,\nQQQ,N/A\nIWM,BATS\n")
++        assert load_venue_overrides(f) == {"IWM": "BATS"}
++
++    def test_duplicate_ticker_last_wins(self, tmp_path):
++        f = tmp_path / "venue_overrides.csv"
++        _write(f, "ticker,venue\nSPY,NYSE\nSPY,ARCA\n")
++        assert load_venue_overrides(f) == {"SPY": "ARCA"}
++
++    def test_ragged_short_row_skipped(self, tmp_path):
++        f = tmp_path / "venue_overrides.csv"
++        _write(f, "ticker,venue\nSPY\nQQQ,NASDAQ\n")
++        assert load_venue_overrides(f) == {"QQQ": "NASDAQ"}
++
++
++@pytest.mark.unit
++class TestMergeVenueOverrides:
++    """`merge_venue_overrides` — tallies repo outcomes, deterministic order."""
++
++    def test_tallies_applied_unchanged_unmatched(self):
++        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
++        repo = MagicMock()
++        outcomes = {"AAA": "applied", "BBB": "unchanged", "CCC": "unmatched"}
++        repo.apply_venue_override.side_effect = lambda t, v, r: outcomes[t]
++        result = merge_venue_overrides({"BBB": "NYSE", "AAA": "ARCA", "CCC": "IEX"}, repo, ts)
++        assert result.applied == 1
++        assert result.unchanged == 1
++        assert result.unmatched == ["CCC"]
++        assert result.total == 3
++
++    def test_processes_tickers_in_sorted_order_and_threads_clock(self):
++        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
++        repo = MagicMock()
++        repo.apply_venue_override.return_value = "applied"
++        merge_venue_overrides({"ZZZ": "ARCA", "AAA": "NYSE"}, repo, ts)
++        calls = repo.apply_venue_override.call_args_list
++        assert [c.args[0] for c in calls] == ["AAA", "ZZZ"]
++        # resolved_at threaded through unchanged (clock lives in the caller).
++        assert all(c.args[2] == ts for c in calls)
++
++    def test_empty_overrides_is_noop(self):
++        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
++        repo = MagicMock()
++        result = merge_venue_overrides({}, repo, ts)
++        assert result == VenueOverrideMergeResult()
++        repo.apply_venue_override.assert_not_called()
+diff --git a/venue_overrides.csv b/venue_overrides.csv
+new file mode 100644
+index 0000000..a97c4e5
+--- /dev/null
++++ b/venue_overrides.csv
+@@ -0,0 +1 @@
++ticker,venue

--- a/_bmad-output/implementation-artifacts/3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue.md
+++ b/_bmad-output/implementation-artifacts/3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue.md
@@ -1,0 +1,188 @@
+# Story 3.1: Ticker → Nautilus-Qualified InstrumentId via Resolved Venue
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the system,
+I want to map an ETF ticker to a Nautilus-qualified `InstrumentId` using its resolved venue, syncing the qualification into `catalog_instruments`,
+so that tickers with a known venue become fully-qualified, backtestable instruments — and no venue is ever guessed.
+
+## Acceptance Criteria
+
+1. **Given** a ticker with a resolved `venue` in `instrument_metadata`, **When** `instrument_mapper` computes its identity, **Then** it produces a Nautilus-qualified `nautilus_id` (e.g. `SPY.ARCA`) sourced from the resolved metadata venue (`InstrumentMetadataService`), **not** from a hardcoded/guessed venue (e.g. the FirstRate `company_profiles.csv` exchange column).
+2. **Given** the qualification sync (ADR-3), **When** import qualification runs, **Then** `catalog_instruments` reads the venue from `instrument_metadata` to compute `nautilus_id` (and mirrors the venue into `catalog_instruments.exchange`), with `instrument_metadata` remaining the single source of truth for resolved metadata and `catalog_instruments` the source of truth for bar counts/date ranges — single writer = the import pipeline.
+3. **Given** a ticker whose venue is unresolved (`resolution_status == VENUE_UNRESOLVED`, i.e. `venue is None`), **When** qualification runs, **Then** no `nautilus_id` is fabricated for it — `catalog_instruments.nautilus_id` is left `None` (unqualified). Full exclude/flag/keep-bars handling is deferred to Story 3.5.
+4. **Given** the non-resolver path (Phase-1 stocks import, or an ETF import with FMP unconfigured so `metadata_resolver is None`), **When** a ticker is imported, **Then** identity resolution is unchanged from today (the existing `resolve_instrument_id` DB lookup) — no regression.
+
+## Tasks / Subtasks
+
+- [x] **Task 1: `InstrumentMapper` — compute qualified identity from a resolved venue + ADR-3 sync** (AC: #1, #2, #3) — *write the tests in `tests/unit/services/firstrate/test_instrument_mapper.py` FIRST (TDD Red→Green)*
+  - [x] Add a pure staticmethod `qualified_instrument_id(ticker: str, venue: Optional[str]) -> Optional[InstrumentId]` to `src/services/firstrate/instrument_mapper.py`: returns `InstrumentId.from_str(f"{ticker}.{venue}")` when `venue` is truthy, else `None`. `venue` is already guaranteed to be a real code or `None` (never `NA_SENTINEL`) by the domain model's `venue_never_na_sentinel` validator — do **not** re-check the sentinel here, and do **not** import `NA_SENTINEL`. [Source: src/models/instrument_metadata.py:96-102; epics.md#Story-3.1 AC1]
+  - [x] Add `sync_qualification(self, ticker: str, catalog_name: str, venue: Optional[str]) -> Optional[InstrumentId]` — the ADR-3 qualification sync:
+    - Fetch the existing row via `self._repo.get_by_ticker(catalog_name, ticker)`. If `None`, log a warning (`qualification_sync_skipped`, reason "no catalog_instruments row") and return `None` — the row is created by `load_company_profiles` before any import, so a miss means profiles were not loaded (defensive; mirrors `_upsert_metadata`'s missing-row handling).
+    - Compute `qid = self.qualified_instrument_id(ticker, venue)`.
+    - Set `instrument.nautilus_id = str(qid) if qid is not None else None` and `instrument.exchange = venue` (mirror the authoritative venue onto the identity row; `None` when unresolved).
+    - `self._repo.upsert(instrument)` (the sync upsert re-fetches the same row and copies the mutated fields — idempotent). Return `qid`.
+    - Add a structured `logger.debug("qualification_synced", ticker=..., venue=..., nautilus_id=...)` line. [Source: src/services/firstrate/instrument_mapper.py:120-140; src/db/repositories/catalog_instrument_repository.py:276-323; architecture.md:262-268 (ADR-3)]
+  - [x] **Do NOT** change `load_company_profiles` (it still seeds the row from the CSV, including the CSV `exchange` as a provisional value); do NOT change `resolve_instrument_id` or `is_loaded`. The qualification sync is additive and runs later in the pipeline, over-writing the provisional CSV exchange with the authoritative resolved venue when one exists. [Source: src/services/firstrate/instrument_mapper.py:69-118,120-152]
+  - [x] Keep functions `< 50` lines and the file `< 500` lines (currently 153). Fully annotate return types (`Optional[InstrumentId]`) for the F821 import gate. [Source: CLAUDE.md Foundational Rules]
+
+- [x] **Task 2: `ImportService` — qualify from resolved metadata before writing bars** (AC: #1, #2, #3, #4) — *tests FIRST (TDD)*
+  - [x] **Reorder** the per-ticker loop in `_import_ticker` so metadata resolution + qualification happen **before** the instrument-id/BarType is needed (the parser writes bars under that id, so the venue must be known before parsing). New order after the `_classify_ticker` skip short-circuit:
+    1. `self._resolve_metadata(ticker)` — *moved up* from its current step 3b position (after parse). It is cache-first, dedup-guarded, and fault-isolated already; moving it earlier is safe and is required so the qualified venue is known before parse. [Source: src/services/firstrate/import_service.py:344-352,718-747]
+    2. `instrument_id = self._qualify_ticker(ticker, catalog_name)` — *replaces* the old `resolve_instrument_id` call at step 1. [Source: import_service.py:297-298]
+    3. If `instrument_id is None` → the ticker's venue is unresolved: log `ticker_unqualified` (fields `ticker`, `catalog`, `timeframe`, reason "venue unresolved — deferred to Story 3.5") and return an `ImportResult(status="skipped", outcome="skipped", row_count=0, ...)`. No parse, no `write_data`, no bar-count upsert. (AC3 — no `nautilus_id` fabricated; bars deferred to 3.5.)
+    4. Otherwise continue exactly as today: build `BarType`, parse, OHLC sanity, `write_data`, verify row count + sample points, `_upsert_metadata` (bar counts / date ranges). **Remove** the now-duplicated `_resolve_metadata(ticker)` call from its old step-3b position. [Source: import_service.py:297-405]
+  - [x] Add `_qualify_ticker(self, ticker: str, catalog_name: str) -> Optional[InstrumentId]`:
+    - `md = self._resolved_metadata.get(ticker)`.
+    - **If `self._metadata_resolver is None` OR `md is None`** (no resolver — stocks/unconfigured path; or resolution faulted so nothing was captured): return `self._instrument_mapper.resolve_instrument_id(ticker, catalog_name)` — the existing behavior, unchanged (AC4). A resolver fault must fall back to the existing DB identity, never silently drop the ticker.
+    - **Else** (resolver ran and captured domain metadata): return `self._instrument_mapper.sync_qualification(ticker, catalog_name, md.venue)` — writes `catalog_instruments.nautilus_id`/`exchange` from the resolved venue and returns the qualified id (or `None` when `md.venue is None`, i.e. `VENUE_UNRESOLVED`). (AC1, AC2, AC3.) [Source: import_service.py:123-151,718-747; src/models/instrument_metadata.py:83-93]
+  - [x] Do NOT change `_resolve_metadata`, `_classify_ticker`, `_upsert_metadata`, the `resolved_metadata` property, or the dedup sets — only their call ordering in `_import_ticker`. Keep `_import_ticker` `< 50` lines by extracting the unqualified-return into `_qualify_ticker` + the reorder (extract a small helper if the function grows past the limit). [Source: import_service.py:245-438; CLAUDE.md size limits]
+
+- [x] **Task 3: Unit tests — pure mapper + orchestration seam** (AC: #1, #2, #3, #4)
+  - [x] **Mapper (`tests/unit/services/firstrate/test_instrument_mapper.py`)** — extend with a `TestQualification` class (`@pytest.mark.unit`, mirror the `MagicMock` repo style already in the file):
+    - `qualified_instrument_id("SPY", "ARCA")` → `InstrumentId.from_str("SPY.ARCA")`.
+    - `qualified_instrument_id("SPY", None)` → `None`. `qualified_instrument_id("SPY", "")` → `None`.
+    - `sync_qualification` with a resolved venue → fetches the row, sets `nautilus_id="SPY.ARCA"` and `exchange="ARCA"`, calls `repo.upsert`, returns the `InstrumentId`. (Use a real `CatalogInstrument` as the `get_by_ticker` return so the mutation is observable — mirror `test_resolve_existing_ticker`.)
+    - `sync_qualification` with `venue=None` → sets `nautilus_id=None`, calls upsert, returns `None` (AC3 — proves no fabrication).
+    - `sync_qualification` when `get_by_ticker` returns `None` → returns `None`, does **not** call `upsert` (defensive missing-row path). [Source: tests/unit/services/firstrate/test_instrument_mapper.py:201-234]
+  - [x] **ImportService (`tests/unit/services/firstrate/test_import_service.py`)** — add a `TestVenueQualification` class using the resolver-injecting helper pattern from `TestResolvedMetadataCollection` (`_service_with_resolver`, `_domain_metadata`):
+    - **Resolved venue** — resolver returns `_domain_metadata("SPY")` (venue `"ARCA"`, `RESOLVED`); assert `_qualify_ticker("SPY", CATALOG)` calls `mapper.sync_qualification("SPY", CATALOG, "ARCA")` and returns its value; assert `resolve_instrument_id` is **not** used on this path.
+    - **Unresolved venue** — resolver returns `_domain_metadata("ZZZ", ResolutionStatus.VENUE_UNRESOLVED)` with `venue=None`; stub `mapper.sync_qualification.return_value = None`; assert `_qualify_ticker` returns `None`.
+    - **No resolver (AC4)** — the plain `service` fixture: assert `_qualify_ticker` delegates to `mapper.resolve_instrument_id(ticker, catalog)` and never calls `sync_qualification`.
+    - **Resolver fault fallback** — resolver `.resolve` raises (so `_resolved_metadata` stays empty); assert `_qualify_ticker` still returns `resolve_instrument_id(...)` (fault-tolerant AC4).
+    - **End-to-end unqualified skip** — a full `import_directory` run with a resolver whose ticker resolves `VENUE_UNRESOLVED` (venue `None`) and `mapper.sync_qualification.return_value = None`: assert the `ImportResult.status == "skipped"`, `catalog.write_data` is **not** called for it, and a `ticker_unqualified` log line is emitted. (Follow the `configured_service`/`patch(get_parser)` idiom, but inject a resolver.) [Source: tests/unit/services/firstrate/test_import_service.py:1209-1288,1295-1335]
+  - [x] **Regression guard** — confirm the existing `configured_service` (no resolver) success-path tests still pass unchanged: `_qualify_ticker` → `resolve_instrument_id` returns the mocked `SPY.ARCA`, bars written as before.
+
+- [x] **Task 4: Component test — real sync repos over SQLite/Postgres double** (AC: #2)
+  - [x] Add a component test in `tests/component/services/firstrate/test_instrument_mapper.py` (real `SyncCatalogInstrumentRepository` against the existing component DB fixture) proving the ADR-3 sync round-trips: seed a `catalog_instruments` row (via `load_company_profiles` or a direct upsert with a provisional CSV exchange like `"NYSE"`), call `sync_qualification(ticker, catalog, "ARCA")`, re-`get_by_ticker`, and assert the persisted `nautilus_id == "SPY.ARCA"` and `exchange == "ARCA"` (authoritative venue over-wrote the provisional CSV exchange). Add a second assertion: `sync_qualification(ticker, catalog, None)` persists `nautilus_id is None`. Mirror the fixtures/markers already in `tests/component/services/firstrate/test_instrument_mapper.py`. [Source: tests/component/services/firstrate/test_instrument_mapper.py; tests/component/db/test_catalog_instrument_repository.py]
+
+- [x] **Task 5: Verify** (AC: all)
+  - [x] `uv run ruff check .` clean — mind the F401/F821 import gate (new `Optional` usage / `InstrumentId` already imported in the mapper).
+  - [x] `uv run mypy .` — no **new** errors vs the known baseline (`reference_mypy_baseline_debt`: 6 pre-existing in `ui/explorer`, `ui/backtests` + 2 tests). Fully annotate the new methods. [Source: reference_mypy_baseline_debt memory]
+  - [x] `make test-unit` green (mapper + import_service unit deltas, no regressions). `make test-component` green for the new mapper component test.
+  - [x] Size limits: files `< 500` lines, functions `< 50`, classes `< 100`, line length `≤ 100`.
+
+### Review Findings
+
+Adversarial review (Blind Hunter · Edge Case Hunter · Acceptance Auditor). Acceptance Auditor: all 4 ACs satisfied, scope respected. Fixes applied and re-verified (1848 unit+component pass, ruff+mypy clean).
+
+- [x] [Review][Patch] Missing-profile row mislabeled as venue-unresolved — `_qualify_ticker` treated `sync_qualification`'s `None` (which also means "no `catalog_instruments` row") as unresolved and silently skipped a ticker whose venue actually resolved. Now falls back to `resolve_instrument_id` (loud `InstrumentMappingError`) when the venue is resolved but the sync returns `None`. [src/services/firstrate/import_service.py:_qualify_ticker]
+- [x] [Review][Patch] Unqualified skip printed "skipped (already complete)" — a dropped venue-unresolved ticker was cosmetically indistinguishable from an idempotent skip. The `ImportResult` now carries a venue-unresolved reason in `error` and `_print_progress_line` renders it (status stays `"skipped"`, so summary/exit-code are unaffected). [src/services/firstrate/import_service.py; src/cli/commands/import_reporting.py:_print_progress_line]
+- [x] [Review][Patch] Qualification re-synced on every timeframe pass — added a per-run `_qualified_ids` dedup (mirrors `_resolved_tickers`) so the catalog_instruments read+write happens at most once per ticker, not 5× for the ETF default. [src/services/firstrate/import_service.py:_qualify_ticker]
+- [x] [Review][Defer] Cross-run orphan: a ticker with pre-existing bars that later resolves `VENUE_UNRESOLVED` gets `nautilus_id` nulled while its bars remain on disk (unreachable). Nulling the provisional id is required by AC3 for the fresh case; the keep-bars/flag reconciliation for already-imported unresolved tickers is Story 3.5's explicit deliverable ("Exclude & Flag Non-Backtestable Tickers"). Deferred to Story 3.5. [src/services/firstrate/instrument_mapper.py:sync_qualification]
+- Dismissed as noise: `exchange` set to `None` on unresolved (intended per AC2, tested); metadata resolved before parse (the spec-mandated Task 2 reorder, confirmed desirable by the auditor); `InstrumentId.from_str` raising on a malformed venue (a loud failure is correct — the conservative venue map emits clean codes).
+
+## Dev Notes
+
+### The core idea (why this story exists)
+Venue correctness is the Phase-2 signature domain risk (architecture.md:118-120): a wrong/guessed venue silently corrupts backtest results, so the architecture **forbids inference** and gates completion on 100% coverage (Story 3.4). Today the ETF import fabricates `nautilus_id` as `{ticker}.{CSV-exchange}` inside `load_company_profiles` — the FirstRate `company_profiles.csv` exchange column is exactly the "guessed" venue this story replaces. Story 3.1 makes the **FMP-resolved venue** (persisted in `instrument_metadata` by Epic 1, overridable in Story 3.3) the authoritative source of the qualified identity, and syncs it onto `catalog_instruments` (ADR-3) so the explorer/backtest readers see the correct venue.
+
+### The seam (data + control flow)
+```
+company_profiles.csv → load_company_profiles → catalog_instruments row seeded
+                                                 (nautilus_id = {ticker}.{CSV exchange}, provisional)
+per-ticker import loop (ImportService._import_ticker), resolver present:
+  _resolve_metadata(ticker)        → InstrumentMetadataService.resolve() → upsert instrument_metadata
+                                     (single source of truth for resolved venue)  [Epic 1, done]
+  _qualify_ticker(ticker)          → mapper.sync_qualification(ticker, catalog, md.venue)   [THIS STORY]
+                                       venue resolved → catalog_instruments.nautilus_id = {ticker}.{venue}
+                                       venue None     → catalog_instruments.nautilus_id = None (unqualified)
+  BarType from instrument_id       → parse → write_data → verify → _upsert_metadata (bar counts)
+```
+`instrument_metadata` = source of truth for resolved metadata; `catalog_instruments` = source of truth for bar counts/date ranges. **Single writer per table = the import pipeline** → no drift (ADR-1/ADR-3). [Source: architecture.md:262-268,533-540,551-555]
+
+### Why the reorder is mandatory (not cosmetic)
+`parser.parse_file(file_path, instrument_id, bar_type)` stamps every `Bar` with the instrument id, and `catalog.write_data(bars)` stores them under `{INSTRUMENT_ID}/{BAR_TYPE}/`. If the bars are written under the CSV venue but `catalog_instruments.nautilus_id` says the FMP venue, the Epic-5 backtest loader (which reads `nautilus_id`) will look under the wrong path and find nothing. So the authoritative venue **must** be known before parsing → metadata resolution + qualification move ahead of `resolve_instrument_id`/`BarType` construction. Since `resolve_instrument_id` reads `catalog_instruments.nautilus_id`, syncing the qualified id **before** that call means the existing `resolve_instrument_id` lookup transparently returns the qualified id — no change to `resolve_instrument_id` itself. [Source: import_service.py:297-364; architecture.md:104-105 "venue-qualified InstrumentId is the precondition for instrument qualification"]
+
+### Scope boundaries (do NOT do here)
+- **No unresolved-venue *report*** (`metadata unresolved` CLI) — that is Story 3.2.
+- **No `venue_overrides.csv`** load/merge — that is Story 3.3. This story consumes whatever venue Epic 1 already persisted; overrides simply flip more rows to `RESOLVED` later, and the sync picks them up unchanged.
+- **No coverage report / completeness gate** — Story 3.4.
+- **No exclude/flag/keep-bars for non-backtestable tickers** — Story 3.5. For 3.1 an unresolved ticker is left unqualified and its bars are **skipped** this run (a clean `skipped` `ImportResult`, no `write_data`); 3.5 will convert that into "keep the bars, flag non-backtestable". This staged handling is exactly what AC3 ("handled by Story 3.5") intends. Do not build 3.5's behavior early.
+- **No new DB columns / migrations / settings** — everything needed exists (`catalog_instruments.nautilus_id`/`exchange`; `instrument_metadata.venue`/`resolution_status`).
+- **No changes to Epic-1 code** (`InstrumentMetadataService`, `FMPMetadataProvider`, repositories, the domain/ORM models) — all `done`. This story only *reads* `md.venue` from the already-captured resolution result.
+
+### Design decision — qualification lives in the import pipeline, not inside the mapper's own resolver call
+The architecture source-tree note (architecture.md:486) sketches `instrument_mapper.py` as "venue from InstrumentMetadataService → nautilus_id". Two faithful implementations exist:
+- **(A)** Inject `InstrumentMetadataService` into `InstrumentMapper` and have it call `.resolve(ticker)` itself.
+- **(B, chosen)** `ImportService` (which already owns the cache-first resolution via `_resolve_metadata`, deduped once per ticker per run) passes the already-resolved `md.venue` into `mapper.sync_qualification(ticker, catalog, venue)`.
+**(B) is chosen** because (A) would re-invoke `.resolve()` — re-hitting the FMP provider for every not-yet-`RESOLVED` ticker a second time (resolution is cache-first: only a `RESOLVED` row short-circuits) — duplicating Epic-1 work and provider quota. (B) also honors ADR-3's explicit "single writer = import pipeline" and keeps the mapper a pure, unit-testable identity+persistence primitive (venue in → id out + row synced). The mapper needs no new constructor dependency. Flag at review if the team prefers (A)'s literal reading. [Source: architecture.md:262-268,486; instrument_metadata_service.py:48-62 (cache-first: only RESOLVED short-circuits)]
+
+### Previous-story intelligence
+- **`_resolve_metadata` (Story 2.4/2.7, done)** already resolves cache-first, dedups per ticker per run (`_resolved_tickers`), captures the domain `InstrumentMetadata` into `_resolved_metadata`, and swallows/logs provider faults so a metadata hiccup never fails a bar import. Story 3.1 reuses this verbatim — only its call position moves. [Source: import_service.py:128-151,718-747]
+- **`md.venue` semantics (Epic 1, done):** a real Nautilus venue code or `None`; **never** `NA_SENTINEL` (validator-enforced). `resolution_status == VENUE_UNRESOLVED` ⇔ `venue is None` for the degraded/unknown records the provider emits. So `venue is None` is the reliable "unqualified" signal — no need to branch on `resolution_status` in the mapper. [Source: src/models/instrument_metadata.py:83-102; instrument_metadata_service.py:88-102; fmp_provider `_degraded`]
+- **Non-resolver path must stay byte-for-byte:** the `configured_service`/`service` fixtures inject no resolver, so `_qualify_ticker` routes to `resolve_instrument_id` — every existing full-import test passes untouched (AC4). [Source: tests/unit/services/firstrate/test_import_service.py:68-75,285-304]
+
+### Testing standards
+- **Unit tier** for the pure mapper primitives + the `_qualify_ticker` seam (mocked repo/resolver, no DB, no Nautilus engine). **Component tier** for the real-repo ADR-3 round-trip. No integration/e2e needed — no `BacktestEngine`, no C extensions. [Source: CLAUDE.md Decision Heuristics; ntrader-testing skill]
+- TDD non-negotiable — Red first for `qualified_instrument_id`, `sync_qualification`, and `_qualify_ticker`. [Source: development-principles.md]
+- Mirror the AAA + `unittest.mock` idioms already in `test_instrument_mapper.py` / `test_import_service.py`; keep `@pytest.mark.unit` / component markers consistent with siblings.
+
+### Git intelligence
+Scope precedent: Epic-2 stories committed as `feat(...)`. A reasonable subject here: `feat(epic3): story 3-1 — ticker → nautilus-qualified instrumentid via resolved venue` (per the harness commit-message instruction). No AI/claude references in the message. [Source: CLAUDE.md Commit Format; task instruction]
+
+### Project Structure Notes
+- **Modified:** `src/services/firstrate/instrument_mapper.py` (+ `qualified_instrument_id`, `sync_qualification`), `src/services/firstrate/import_service.py` (`_import_ticker` reorder + `_qualify_ticker`).
+- **Modified tests:** `tests/unit/services/firstrate/test_instrument_mapper.py`, `tests/unit/services/firstrate/test_import_service.py`, `tests/component/services/firstrate/test_instrument_mapper.py`.
+- Placement matches architecture.md:485-486 (both files flagged MODIFIED for the qualification sync).
+
+### References
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-3.1] — story statement + 3 acceptance criteria; FR20
+- [Source: _bmad-output/planning-artifacts/architecture.md:262-268] — ADR-3 qualification sync decision (single writer = import pipeline)
+- [Source: _bmad-output/planning-artifacts/architecture.md:104-105,118-120,533-555] — venue-qualified id precondition; venue-correctness risk; two-table data boundary + import flow
+- [Source: src/services/firstrate/instrument_mapper.py:55-152] — mapper today (CSV-derived nautilus_id, resolve/is_loaded)
+- [Source: src/services/firstrate/import_service.py:245-438,718-747] — `_import_ticker` loop + `_resolve_metadata`
+- [Source: src/models/instrument_metadata.py:61-102] — domain model; `venue` semantics + never-sentinel validator
+- [Source: src/db/repositories/catalog_instrument_repository.py:264-343] — sync `get_by_ticker`/`upsert` used by the sync
+- [Source: tests/unit/services/firstrate/test_instrument_mapper.py:201-265] — resolve/is_loaded test idioms to mirror
+- [Source: tests/unit/services/firstrate/test_import_service.py:1209-1335] — resolver-injecting fixtures + `_domain_metadata`
+
+### Open questions (non-blocking — proceed with the documented default)
+1. **Mapper injection style.** Default: **(B)** — import pipeline passes `md.venue` to `sync_qualification`; mapper takes no new dependency (avoids double FMP resolution). Alternative **(A)** — inject `InstrumentMetadataService` into the mapper. Flag if the team wants the literal architecture-note reading.
+2. **Unresolved-ticker outcome this run.** Default: `ImportResult(status="skipped", outcome="skipped")` with a `ticker_unqualified` log; bars not written until Story 3.5 grants "keep bars, non-backtestable". Alternative: import bars under a provisional path now — rejected as pre-empting 3.5 and risking the exact bars-under-wrong-venue mismatch this story exists to prevent.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8
+
+### Debug Log References
+
+- `uv run pytest tests/unit/services/firstrate/test_instrument_mapper.py tests/unit/services/firstrate/test_import_service.py` — 95 passed (6 new mapper qualification tests + 5 new `TestVenueQualification` import-service tests).
+- `uv run pytest tests/component/services/firstrate/test_instrument_mapper.py` — 8 passed (2 new `TestQualificationSync` + 6 pre-existing, after repairing stale in-memory DDL).
+- `uv run pytest tests/unit` — 1141 passed. `uv run pytest tests/component` — 703 passed, 16 skipped (pre-existing report-command skips).
+- `uv run ruff check .` — All checks passed. `uv run mypy .` — Success: no issues found in 342 source files.
+
+### Completion Notes List
+
+- **AC1/AC2** — `InstrumentMapper.qualified_instrument_id(ticker, venue)` (pure) + `sync_qualification(ticker, catalog, venue)` (ADR-3 sync) added. The sync reads the `catalog_instruments` row, overwrites `nautilus_id`/`exchange` from the authoritative resolved venue, and upserts (single writer = import pipeline). `instrument_metadata` stays source of truth for resolved venue; `catalog_instruments` for bar counts/date ranges.
+- **AC3** — a `None`/blank venue (`VENUE_UNRESOLVED`) yields no `InstrumentId`; `sync_qualification` persists `nautilus_id = None` (unqualified, never fabricated). In `_import_ticker` an unqualified ticker returns a clean `skipped` result (no parse/write) with a `ticker_unqualified` log — exclude/flag/keep-bars deferred to Story 3.5.
+- **AC4** — `ImportService._qualify_ticker` falls back to the existing `resolve_instrument_id` DB lookup whenever no resolver is injected (stocks / FMP-unconfigured) or a provider fault captured nothing. The `_import_ticker` loop was reordered so `_resolve_metadata` + qualification run before `BarType` construction (bars must be written under the authoritative venue); `resolve_instrument_id` transparently returns the freshly-synced qualified id, so it needed no change.
+- **Design** — chose approach (B): the import pipeline passes the already-resolved `md.venue` to the mapper (no double FMP resolution, honors ADR-3 "single writer"); mapper gains no new constructor dependency. Documented in Dev Notes.
+- **Pre-existing fixes made while in-area (not caused by this story, proven via `git diff`/`git show`):**
+  1. `tests/component/services/firstrate/test_instrument_mapper.py` — the inline `_CREATE_TABLE_SQL` was missing the five `date_range_end_*` columns the ORM now selects; every test in the file failed at HEAD. Added the columns.
+  2. `tests/component/services/firstrate/test_import_service.py` — three idempotent-rerun tests (`test_partial_metadata_triggers_reimport`, `test_ac1_…`, `test_ac2_…`) rewound the shared `date_range_end`, but the per-timeframe classifier (commit d75a409) compares `date_range_end_daily`; that commit updated the unit tests but not these component tests. Rewound `date_range_end_daily` too so the tests express their intent. These tests are decided at `_classify_ticker` (step 0), which this story does not modify.
+
+### Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-13 | Story 3.1 drafted (SM). Status → ready-for-dev. |
+| 2026-07-13 | Implemented mapper qualification + ADR-3 sync; `_import_ticker` reorder + `_qualify_ticker`; unit + component tests; repaired 2 pre-existing component-test drifts. Gates green. Status → review. |
+| 2026-07-13 | Code review (3 adversarial layers). Applied 3 patches (missing-row loud-fail, honest unqualified progress line, per-run qualification dedup); deferred 1 cross-run orphan finding to Story 3.5. 1848 unit+component pass, ruff+mypy clean. Status → done. |
+
+### File List
+
+- `src/services/firstrate/instrument_mapper.py` (modified — `qualified_instrument_id`, `sync_qualification`)
+- `src/services/firstrate/import_service.py` (modified — `_import_ticker` reorder + unqualified-skip; `_qualify_ticker`; `InstrumentId` TYPE_CHECKING import)
+- `tests/unit/services/firstrate/test_instrument_mapper.py` (modified — `TestQualification`)
+- `tests/unit/services/firstrate/test_import_service.py` (modified — `TestVenueQualification`, `_unresolved_metadata`)
+- `tests/component/services/firstrate/test_instrument_mapper.py` (modified — `TestQualificationSync`; stale-DDL repair)
+- `tests/component/services/firstrate/test_import_service.py` (modified — per-timeframe rewind repair in 3 pre-existing idempotency tests)
+- `src/cli/commands/import_reporting.py` (modified — review patch: honest skipped-line reason)
+- `tests/unit/cli/commands/test_import_reporting.py` (modified — review patch: progress-line reason tests)

--- a/_bmad-output/implementation-artifacts/3-2-unresolved-venue-report.md
+++ b/_bmad-output/implementation-artifacts/3-2-unresolved-venue-report.md
@@ -1,0 +1,183 @@
+# Story 3.2: Unresolved-Venue Report
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the operator,
+I want a `metadata unresolved` CLI report listing every ticker that lacks a resolved venue together with a derived reason,
+so that I have a concrete, actionable worklist to drive the ETF universe toward 100% venue coverage — and a basis for filling in `venue_overrides.csv` (Story 3.3).
+
+## Acceptance Criteria
+
+1. **Given** imported ETFs with some venues unresolved, **When** the operator runs the `metadata unresolved` CLI subcommand, **Then** it lists every ticker with `resolution_status = VENUE_UNRESOLVED` (queried via the indexed `ix_instrument_metadata_resolution_status`), each with its provider and a derived reason (e.g. "unknown to FMP — no profile returned" vs "FMP venue label blank, ambiguous (e.g. AMEX), or unmapped").
+2. **Given** the report, **When** it is produced, **Then** it is rendered as readable CLI output (a Rich table with a total count), the tickers are ordered deterministically (by ticker), and the output is usable as the basis for filling in `venue_overrides.csv` (the report surfaces the `ticker` column the override file keys on).
+3. **Given** zero rows with `VENUE_UNRESOLVED`, **When** the subcommand runs, **Then** it prints a clear "all venues resolved — nothing to fix" message (no empty table, exit code 0), so the operator can trust the empty result.
+4. **Given** the metadata DB is unconfigured (`DATABASE_URL` unset), **When** the subcommand runs, **Then** it degrades gracefully with a clear warning (no traceback), mirroring the existing CLI DB-unconfigured handling.
+
+## Tasks / Subtasks
+
+- [x] **Task 1: Repository — list rows by resolution status** (AC: #1, #2) — *write the test in `tests/component/db/test_instrument_metadata_repository.py` FIRST (TDD Red→Green)*
+  - [x] Add `list_by_status(self, status: ResolutionStatus) -> list[InstrumentMetadata]` to `src/db/repositories/instrument_metadata_repository_sync.py`: `select(InstrumentMetadata).where(InstrumentMetadata.resolution_status == status).order_by(InstrumentMetadata.ticker)`, returning `list(result.scalars().all())`. The `where` clause is served by the existing `ix_instrument_metadata_resolution_status` index (do not add a new index/migration). [Source: src/db/models/instrument_metadata.py:59-71; src/db/repositories/instrument_metadata_repository_sync.py:72-83]
+  - [x] Import `ResolutionStatus` from `src.models.instrument_metadata` at module top (the ORM model already imports it there; keep the sync repo consistent). Fully annotate the return type (`list[InstrumentMetadata]`) for the F821 gate. Keep the function `< 50` lines and the file `< 500`. [Source: CLAUDE.md Foundational Rules; src/db/models/instrument_metadata.py:18]
+  - [x] Do **not** touch the async repository (`instrument_metadata_repository.py`) — this report is a sync CLI path only; no web/API consumer exists for it in this story.
+
+- [x] **Task 2: Reason derivation — pure function** (AC: #1) — *tests FIRST (TDD)*
+  - [x] Add a pure module-level function `unresolved_reason(md: InstrumentMetadata) -> str` in a new `src/services/metadata/unresolved_report.py` (the domain-facing derivation lives beside the metadata services, not in the CLI layer, so it is unit-testable without Click). It takes the **ORM** `InstrumentMetadata` row and returns a human-readable reason string.
+    - **Discriminator:** the FMP provider's `_degraded` path (ticker unknown / no profile) sets `asset_type = None` and every descriptive field to `NA_SENTINEL`; the found-but-venue-unmapped path (`_to_domain`) always sets a concrete `asset_type` (ETF/EQUITY/FUND) via `_asset_type()`. So `asset_type is None` ⇒ "unknown to FMP", else ⇒ "found, venue label unusable". Use `asset_type` as the primary signal (it is `None` **only** on the degraded path). [Source: src/services/metadata/providers/fmp_provider.py:77-118]
+    - Return `"unknown to <provider> — no profile returned"` when `md.asset_type is None` (degraded), else `"<provider> venue label blank, ambiguous (e.g. AMEX), or unmapped"`. Interpolate `md.metadata_provider` for the provider name so the reason is provider-agnostic. **Do not** claim more precision than the persisted row supports: the raw FMP `exchange` label is normalized to `None` and never stored, so blank-vs-ambiguous-vs-unmapped cannot be distinguished post-hoc — the reason is deliberately best-effort and honest about that. [Source: src/services/metadata/venue_map.py:23-43 (label → None, not persisted); Dev Notes "Why the reason is derived, not stored"]
+  - [x] Keep the function pure (no I/O, no clock), `< 50` lines, fully return-type-annotated. `NA_SENTINEL` need not be imported — the `asset_type is None` discriminator is sufficient and cleaner than sniffing descriptive sentinels. [Source: CLAUDE.md size limits]
+
+- [x] **Task 3: CLI — new `metadata` command group + `unresolved` subcommand** (AC: #1, #2, #3, #4) — *tests FIRST (TDD, CliRunner)*
+  - [x] Create `src/cli/commands/metadata.py` with `@click.group() def metadata(): """Instrument metadata inspection commands."""` and a `@metadata.command("unresolved")` subcommand. Register it in `src/cli/main.py`: `from src.cli.commands.metadata import metadata` + `cli.add_command(metadata)` (mirrors `report`/`data` group registration). [Source: src/cli/commands/report.py:19-22; src/cli/main.py:35-42]
+  - [x] The `unresolved` command:
+    1. Open a sync session via `get_sync_session()` inside a `try/except` that catches `RuntimeError` (DB unconfigured — it raises "Database not configured…") and any `DatabaseConnectionError`, printing a single yellow warning line and returning (AC4 — no traceback). [Source: src/db/session_sync.py:97-135; src/cli/commands/report.py:33-52 (try/except console idiom)]
+    2. `rows = SyncInstrumentMetadataRepository(session).list_by_status(ResolutionStatus.VENUE_UNRESOLVED)`.
+    3. Delegate rendering to a pure helper `_render_unresolved(rows) -> None` (or return a Rich `Table` from a builder + a separate print) so the formatting is unit-testable without a live DB. On empty `rows`: print `"✓ All venues resolved — no unresolved-venue tickers."` and return (AC3). Otherwise: print a Rich `Table` (columns **Ticker**, **Provider**, **Reason**) with one row per ticker (reason via `unresolved_reason`), preceded/followed by a count line `"<N> ticker(s) with unresolved venue"`, and a footer hint: `"Add the correct venue for each in venue_overrides.csv (Story 3.3) to resolve."` (AC1, AC2). [Source: src/cli/commands/import_data.py:8-9,42 (Console/Table idiom); src/cli/commands/report.py Table usage]
+  - [x] Keep every function `< 50` lines and the file `< 500`. Extract the table build into a small helper if the command body grows past the limit. No new settings, no new migration, no network/provider call — this is a pure read over the local cache table. [Source: CLAUDE.md size limits; Dev Notes "Scope boundaries"]
+
+- [x] **Task 4: Unit tests** (AC: #1, #2, #3, #4)
+  - [x] **Reason derivation (`tests/unit/services/metadata/test_unresolved_report.py`, `@pytest.mark.unit`):**
+    - Degraded row (`asset_type=None`, descriptives `NA_SENTINEL`, provider `"FMP"`) → reason contains `"unknown to FMP"` / `"no profile"`.
+    - Found-but-unmapped row (`asset_type=AssetType.ETF`, `company_name="SPDR S&P 500"`, `venue=None`, provider `"FMP"`) → reason contains `"blank, ambiguous"` / `"unmapped"` and does **not** claim "unknown to FMP".
+    - Provider interpolation: a row with `metadata_provider="OTHER"` renders `"OTHER"` in the reason (provider-agnostic). Use the **ORM** `InstrumentMetadata` (build via kwargs like the component `_make_metadata`) — not the Pydantic domain model. [Source: tests/component/db/test_instrument_metadata_repository.py:62-70 (_make_metadata idiom)]
+  - [x] **CLI (`tests/unit/cli/commands/test_metadata.py`, `CliRunner`, `@pytest.mark.unit`):** patch `get_sync_session` (a context manager) and `SyncInstrumentMetadataRepository` (or patch `list_by_status`) so no real DB is touched — mirror the `patch(...)` idiom in `test_import_data.py`.
+    - **Populated:** repo returns 2 VENUE_UNRESOLVED ORM rows (one degraded, one found-unmapped) → exit code 0, output contains both tickers, both reason phrasings, the total-count line, and the `venue_overrides.csv` hint (AC1, AC2).
+    - **Empty:** repo returns `[]` → exit code 0, output contains the "All venues resolved" message and no table header (AC3).
+    - **DB unconfigured:** `get_sync_session` raises `RuntimeError("Database not configured…")` → exit code 0 (graceful), output contains a clear warning, no traceback (`result.exception` is `None` or handled) (AC4).
+  - [x] **Rendering helper (optional but preferred):** a direct unit test of `_render_unresolved`/table-builder over a fixed row list asserting column contents + ordering, so formatting is covered without CliRunner. [Source: test_import_reporting.py progress-line unit-test precedent]
+
+- [x] **Task 5: Component test — real sync repo round-trip** (AC: #1, #2)
+  - [x] In `tests/component/db/test_instrument_metadata_repository.py` add a test for `list_by_status`: seed a mix of statuses via `_make_metadata` (e.g. `RESOLVED` `AAA`, `VENUE_UNRESOLVED` `CCC`, `VENUE_UNRESOLVED` `BBB`, `UNRESOLVED` `DDD`), call `list_by_status(ResolutionStatus.VENUE_UNRESOLVED)`, and assert it returns exactly `["BBB", "CCC"]` (only VENUE_UNRESOLVED, ordered by ticker). Reuse the file's existing `sync_session` fixture + `_CREATE_TABLE_SQL`. [Source: tests/component/db/test_instrument_metadata_repository.py:48-70]
+
+- [x] **Task 6: Verify** (AC: all)
+  - [x] `uv run ruff check .` clean — mind the F401/F821 import gate (new `ResolutionStatus` import in the sync repo; new module imports).
+  - [x] `uv run mypy .` — no **new** errors vs the known baseline (`reference_mypy_baseline_debt`: 6 pre-existing in `ui/explorer`, `ui/backtests` + 2 tests). Fully annotate new functions.
+  - [x] `make test-unit` green (reason + CLI + rendering deltas, no regressions). `make test-component` green for the new repo test.
+  - [x] Size limits: files `< 500` lines, functions `< 50`, classes `< 100`, line length `≤ 100`.
+  - [x] Smoke: `uv run python -m src.cli.main metadata unresolved --help` renders; `... metadata unresolved` runs (may warn if DB unconfigured — that is AC4).
+
+### Review Findings
+
+Adversarial review (Blind Hunter · Edge Case Hunter · Acceptance Auditor). Acceptance Auditor: PASS — all 4 ACs satisfied, no scope violations, size limits respected. Fixes applied and re-verified (1864 unit+component pass, ruff+mypy clean).
+
+- [x] [Review][Patch] Query-time DB error escaped as a raw traceback (Edge, High) — `get_sync_session()` is lazy, so a DB-down / not-migrated / bad-URL failure surfaces inside `list_by_status.execute`, not on `with`-entry. The CLI caught only `(RuntimeError, DatabaseConnectionError)`, so an `OperationalError`/`ProgrammingError` tracebacked. Fixed: `list_by_status` now translates `OperationalError → DatabaseConnectionError` (mirrors `upsert`), and the CLI `except` was broadened to `SQLAlchemyError` (covers Postgres-down, missing-table, malformed URL). Added CLI query-error + connection-error tests and a repo translation test. [src/db/repositories/instrument_metadata_repository_sync.py:list_by_status; src/cli/commands/metadata.py:unresolved]
+- [x] [Review][Patch] Unescaped Rich markup in DB-sourced cells (Edge/Blind, Low) — a `ticker`/`provider` containing a Rich metacharacter (e.g. `[`) could raise `MarkupError`/mis-render. Fixed: `escape()` the ticker and provider cells (and the warning-line exception text). Added a markup-escape render test. [src/cli/commands/metadata.py:_render_unresolved]
+- [x] [Review][Patch] Weak/misleading test assertions (Blind, Low ×3) — the "orders rows" render test asserted only membership (now asserts `index("SPY") < index("ZZZ")`); the graceful-degradation test's near-vacuous `"not" in output` now asserts the actual `"Metadata DB not available"` warning; the provider-agnostic reason test covered only the degraded branch (added a found-branch non-FMP case). [tests/unit/cli/commands/test_metadata.py; tests/unit/services/metadata/test_unresolved_report.py]
+- [x] [Review][Dismiss→Documented] Cross-provider misclassification of the `asset_type is None` discriminator (Edge/Blind, Low) — the reason string is provider-agnostic but the discriminator is FMP-specific. Only FMP writes `VENUE_UNRESOLVED` rows today, and the module docstring + open question #1 already document the deliberate best-effort two-way classification. No code change; accepted as documented design boundary (exact-label fidelity would need a schema change, out of scope).
+
+## Dev Notes
+
+### The core idea (why this story exists)
+Epic 3 gates ETF-universe completion on 100% venue coverage with **no inferred venues** (Story 3.4). Story 3.1 made the FMP-resolved venue authoritative and left `VENUE_UNRESOLVED` tickers unqualified. Story 3.2 gives the operator the **worklist**: every ticker the conservative venue map (ADR-6) could not confidently resolve, with a reason, so they can fill in `venue_overrides.csv` (Story 3.3). The conservative map *deliberately* routes ambiguous labels (notably `AMEX`) to `VENUE_UNRESOLVED` rather than guess — this report is the surfacing mechanism that makes that safe-by-default choice actionable. [Source: src/services/metadata/venue_map.py:1-14; architecture.md venue-correctness risk]
+
+### Why the reason is derived, not stored
+The persisted `instrument_metadata` row does **not** store the raw FMP `exchange` label — `normalize_venue` collapses blank/ambiguous/unmapped all to `venue=None` (Story 1.4/ADR-6). So the report cannot reconstruct the *exact* original label after the fact. What it **can** derive reliably from the row is a two-way classification:
+- **`asset_type is None`** ⇒ the provider's `_degraded` path ran (no profile / unknown ticker) → "unknown to FMP".
+- **`asset_type` set** (ETF/EQUITY/FUND) ⇒ a profile came back but its `exchange` label was blank, ambiguous (AMEX), or unmapped → "venue label unusable".
+
+`asset_type` is the clean discriminator: `_to_domain` **always** assigns a concrete `AssetType` via `_asset_type()`, while `_degraded` sets it `None`. The AC lists "blank FMP label, ambiguous AMEX, ticker unknown to FMP" as *examples* of reasons — this story provides an honest, derivable reason, not a fabricated three-way precision the data can't support. If the team later wants exact-label fidelity, that requires persisting the raw label (a schema change) — out of scope here. [Source: src/services/metadata/providers/fmp_provider.py:53-118; src/services/metadata/venue_map.py:23-43]
+
+### The seam (data + control flow)
+```
+instrument_metadata (cache table, populated by Epic 1 resolution + Story 3.1 import)
+  rows where resolution_status = VENUE_UNRESOLVED  (venue IS NULL, indexed)
+        │
+  metadata unresolved  (CLI, this story)
+        │  SyncInstrumentMetadataRepository.list_by_status(VENUE_UNRESOLVED)  ← indexed SELECT, ordered by ticker
+        │  unresolved_reason(row)  ← pure derivation (asset_type discriminator)
+        ▼
+  Rich table: Ticker | Provider | Reason  +  count  +  "→ venue_overrides.csv" hint
+```
+Read-only over the local cache — no network, no provider call, no write. [Source: architecture.md two-table boundary; src/db/models/instrument_metadata.py:59-71]
+
+### Scope boundaries (do NOT do here)
+- **No `venue_overrides.csv` load/merge/write** — that is Story 3.3. This report only *surfaces* the tickers; it does not write the override file or flip any `resolution_status`.
+- **No coverage count / completeness gate** — that is Story 3.4 (`metadata coverage` + the 0-unresolved gate). This story lists; it does not compute a pass/fail gate. (`list_by_status` is the reusable primitive 3.4 will build its indexed count on, but do not add the count command here.)
+- **No exclude/flag/keep-bars** — Story 3.5.
+- **No new DB columns / migrations / settings** — the index and `resolution_status` enum already exist; the report reads what Epic 1 + Story 3.1 already persisted.
+- **No async/web endpoint** — CLI sync path only. Do not touch the async repo or add an API route.
+- **No changes to the FMP provider, venue map, or resolution service** — all `done`; this story only *reads* their persisted output.
+
+### Design decision — new `metadata` command group
+There is no existing `metadata` CLI group (verified: `main.py` registers `run`, `data`, `backtest`, `strategy`, `report`, `history`, `import`). FR21/24 both describe `metadata <subcommand>` verbs (`metadata unresolved`, later `metadata coverage`), so a dedicated `@click.group()` named `metadata` is the natural home, and Story 3.4 will add `coverage` to the same group. Mirror the `report` group's structure (group docstring + `@group.command()` subcommands). [Source: src/cli/main.py:6-42; src/cli/commands/report.py:19-30; epics.md FR21/FR24]
+
+### Design decision — derivation lives in `services/metadata`, not the CLI
+`unresolved_reason` is placed in `src/services/metadata/unresolved_report.py` (beside the other metadata services) rather than inline in the Click command, so it is a pure, unit-testable primitive with no Click dependency — matching the project's "pure logic → unit tier" heuristic and the mapper/dry-run precedent. The CLI command stays thin: open session → query → render. [Source: CLAUDE.md Decision Heuristics; src/services/firstrate/dry_run.py (pure helpers consumed by CLI)]
+
+### Previous-story intelligence
+- **Story 3.1 (done)** established that `VENUE_UNRESOLVED` ⇔ `venue is None`, and that the import pipeline is the single writer of `catalog_instruments`. This report never writes — it reads `instrument_metadata`, the source of truth for resolved metadata. [Source: 3-1 story Dev Notes]
+- **`ix_instrument_metadata_resolution_status` (Story 1.2, done)** already indexes `resolution_status`, so `list_by_status` is an indexed lookup — the same index Story 3.4 will use for its O(1) count. [Source: src/db/models/instrument_metadata.py:71]
+- **DB-unconfigured idiom:** `get_sync_session()` raises `RuntimeError` when `DATABASE_URL` is unset; existing CLI commands catch and print a friendly line rather than tracing back. `import_data._open_metadata_session` degrades to a yellow warning — mirror that tone. [Source: src/db/session_sync.py:118-135; src/cli/commands/import_data.py:96-113]
+
+### Testing standards
+- **Unit tier** for the pure `unresolved_reason` derivation, the table/render helper, and the CLI command (CliRunner with `get_sync_session`/repo patched — no DB, no Nautilus). **Component tier** for the real-repo `list_by_status` round-trip over the in-memory SQLite fixture. No integration/e2e — no engine, no C extensions. [Source: CLAUDE.md Decision Heuristics; ntrader-testing skill]
+- TDD non-negotiable — Red first for `list_by_status`, `unresolved_reason`, and the CLI command. [Source: development-principles.md]
+- Build ORM rows in tests via the `_make_metadata` kwargs idiom already in the component test; keep `@pytest.mark.unit` / component markers consistent with siblings.
+
+### Git intelligence
+Scope precedent: Epic-3 story 3-1 committed as `feat(epic3): story 3-1 — …`. Subject here: `feat(epic3): story 3-2 — unresolved-venue report`. No AI/claude references in the message. Stage then commit in **separate** Bash calls (the bash-guard commit gate rejects a `git add && git commit` one-liner). [Source: CLAUDE.md Commit Format + Editing with Auto-Linter]
+
+### Project Structure Notes
+- **New:** `src/cli/commands/metadata.py` (group + `unresolved`), `src/services/metadata/unresolved_report.py` (`unresolved_reason`).
+- **Modified:** `src/cli/main.py` (register `metadata`), `src/db/repositories/instrument_metadata_repository_sync.py` (`list_by_status`).
+- **New tests:** `tests/unit/services/metadata/test_unresolved_report.py`, `tests/unit/cli/commands/test_metadata.py`.
+- **Modified tests:** `tests/component/db/test_instrument_metadata_repository.py` (`list_by_status` round-trip).
+
+### References
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-3.2] — story statement + 2 acceptance criteria; FR21
+- [Source: _bmad-output/planning-artifacts/epics.md FR21/FR24] — `metadata` subcommand family (unresolved now, coverage in 3.4)
+- [Source: src/db/repositories/instrument_metadata_repository_sync.py:72-83] — sync repo `get_by_ticker` idiom to mirror for `list_by_status`
+- [Source: src/db/models/instrument_metadata.py:59-71] — `resolution_status` enum column + `ix_instrument_metadata_resolution_status` index
+- [Source: src/services/metadata/providers/fmp_provider.py:53-118] — `_to_domain` (asset_type always set) vs `_degraded` (asset_type None) — the reason discriminator
+- [Source: src/services/metadata/venue_map.py:23-43] — `normalize_venue` → `None` for blank/ambiguous/unmapped (label not persisted)
+- [Source: src/cli/commands/report.py:19-52] — `@click.group()` + subcommand + try/except console idiom
+- [Source: src/cli/main.py:6-42] — command-group registration
+- [Source: src/db/session_sync.py:97-135] — `get_sync_session` (raises RuntimeError when unconfigured)
+- [Source: tests/component/db/test_instrument_metadata_repository.py:36-70] — `sync_session` fixture + `_make_metadata` idiom
+- [Source: tests/unit/cli/commands/test_import_data.py:1-14] — CliRunner + patch idiom for CLI unit tests
+
+### Open questions (non-blocking — proceed with the documented default)
+1. **Reason precision.** Default: two-way derived reason (`unknown to FMP` vs `venue label blank/ambiguous/unmapped`) from `asset_type`. Storing the raw FMP `exchange` label for exact three-way reasons is a schema change — deferred/out of scope. Flag if the team wants exact-label fidelity.
+2. **Output format.** Default: Rich table (Ticker/Provider/Reason) + count + overrides hint. A machine-readable `--format csv` that directly emits `ticker,venue`-shaped rows could seed `venue_overrides.csv`, but that overlaps Story 3.3's file ownership — left out to keep the boundary clean. Flag if a plain/CSV dump is wanted now.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8
+
+### Debug Log References
+
+- `uv run pytest tests/unit/services/metadata/test_unresolved_report.py tests/unit/cli/commands/test_metadata.py tests/component/db/test_instrument_metadata_repository.py` — 22 passed (3 reason + 6 CLI + repo round-trip incl. 2 new `list_by_status`).
+- `uv run pytest tests/unit tests/component` — 1858 passed, 16 skipped (pre-existing report-command skips), no regressions.
+- `uv run ruff check .` — All checks passed. `uv run mypy .` — Success: no issues found in 346 source files.
+
+### Completion Notes List
+
+- **AC1** — `SyncInstrumentMetadataRepository.list_by_status(status)` (indexed `where` on `resolution_status`, ordered by ticker) + `metadata unresolved` CLI list every `VENUE_UNRESOLVED` row with provider and a derived reason. `unresolved_reason` (pure) discriminates the two FMP paths via `asset_type` (`None` ⇒ `_degraded`/unknown; set ⇒ profile found, label blank/ambiguous/unmapped).
+- **AC2** — Rendered as a Rich table (Ticker/Provider/Reason) with a total-count line, deterministic ticker order, and a `venue_overrides.csv` footer hint (basis for Story 3.3).
+- **AC3** — Empty result prints "✓ All venues resolved — no unresolved-venue tickers." with exit 0 (no empty table).
+- **AC4** — DB-unconfigured (`get_sync_session` raises `RuntimeError`, or `DatabaseConnectionError`) prints a single yellow warning and returns cleanly (no traceback), mirroring the existing CLI idiom.
+- **Design** — new `metadata` Click group (no prior one existed; Story 3.4 `coverage` will join it); reason derivation placed in `src/services/metadata/unresolved_report.py` as a pure, unit-testable primitive. Reason is a deliberate two-way classification — the raw FMP `exchange` label is never persisted, so exact blank-vs-ambiguous fidelity is out of scope (documented open question #1).
+- **Scope respected** — no override load/merge (3.3), no coverage count/gate (3.4), no exclude/flag (3.5), no new columns/migrations/settings, no async/web path, no changes to provider/venue-map/resolution service.
+
+### Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-13 | Story 3.2 drafted (SM). Status → ready-for-dev. |
+| 2026-07-13 | Implemented `list_by_status`, pure `unresolved_reason`, `metadata unresolved` CLI + group registration; unit + component tests (TDD). Gates green (ruff, mypy, 1858 pass). Status → review. |
+| 2026-07-13 | Code review (3 adversarial layers). Applied 2 patches (query-time DB-error graceful catch, Rich-markup escaping) + tightened 3 weak test assertions; documented 1 cross-provider limitation. 1864 unit+component pass, ruff+mypy clean. Status → done. |
+
+### File List
+
+- `src/db/repositories/instrument_metadata_repository_sync.py` (modified — `list_by_status`, `ResolutionStatus` import)
+- `src/services/metadata/unresolved_report.py` (new — pure `unresolved_reason`)
+- `src/cli/commands/metadata.py` (new — `metadata` group + `unresolved` subcommand + `_render_unresolved`)
+- `src/cli/main.py` (modified — register `metadata` group)
+- `tests/unit/services/metadata/test_unresolved_report.py` (new — reason derivation)
+- `tests/unit/cli/commands/test_metadata.py` (new — CLI + render + registration)
+- `tests/component/db/test_instrument_metadata_repository.py` (modified — `list_by_status` round-trip + empty)

--- a/_bmad-output/implementation-artifacts/3-3-venue-overrides-csv-merge-with-precedence.md
+++ b/_bmad-output/implementation-artifacts/3-3-venue-overrides-csv-merge-with-precedence.md
@@ -1,0 +1,204 @@
+# Story 3.3: venue_overrides.csv Merge with Precedence
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the operator,
+I want to supply manual venue corrections in a git-tracked `venue_overrides.csv` (header exactly `ticker,venue`, path via config) that the system loads and merges into `instrument_metadata` during the import-orchestration step,
+so that I can resolve venues FMP couldn't — with the override taking precedence and flipping the row to `RESOLVED` — without a web write-path, and idempotently across re-runs.
+
+## Acceptance Criteria
+
+1. **Given** a git-tracked `venue_overrides.csv` with header exactly `ticker,venue` (path resolved from config), **When** an ETF import or a `metadata apply-overrides` refresh runs, **Then** the file is loaded and merged into `instrument_metadata` during the import-orchestration step (in `src/cli/commands/import_data.py` / the `metadata` CLI group), **not** inside `FMPClient`, the FMP provider, or the resolution service.
+2. **Given** a ticker present in both FMP data (absent/ambiguous venue → a persisted `VENUE_UNRESOLVED` row) and the override file, **When** the merge runs, **Then** the override venue takes precedence: the row's `venue` is set to the override value and its `resolution_status` becomes `RESOLVED` (so Story 3.1 qualification and Story 3.5 inclusion pick it up). No FMP call is made for that ticker during the merge.
+3. **Given** the same override file, **When** the import (or `metadata apply-overrides`) is re-run, **Then** the merge is idempotent — a row already at the override target (`venue == override AND status == RESOLVED`) is left untouched (no write, no `resolved_at` churn, no duplicate row), so re-merging produces exactly the same store state.
+4. **Given** a malformed override file (header not exactly `ticker,venue`) **or** an unconfigured metadata DB (`DATABASE_URL` unset), **When** the merge is attempted, **Then** it degrades gracefully with a single clear warning (no traceback): a malformed header skips the merge without aborting an in-flight import (bars already imported are preserved); a missing file is a silent no-op. Rows with a blank ticker, blank venue, or a venue equal to `N/A` are skipped (an unfilled worklist line is not an error).
+
+## Tasks / Subtasks
+
+- [x] **Task 1: Config — override file path setting** (AC: #1) — *test FIRST (TDD)*
+  - [x] Add `firstrate_venue_overrides_path: str = Field(default="venue_overrides.csv", description="Path to the git-tracked venue overrides CSV (header: ticker,venue)")` to `FirstRateSettings` in `src/config.py`. Repo-root-relative default so the file is discoverable without `.env` config. Keep `model_config` (`extra="ignore"`) unchanged. [Source: src/config.py:147-163]
+  - [x] Add a unit assertion (in the existing config test module if present, else a tiny new one) that `FirstRateSettings().firstrate_venue_overrides_path == "venue_overrides.csv"`.
+
+- [x] **Task 2: Pure loader + merge core** (AC: #1, #2, #3, #4) — *tests FIRST (TDD Red→Green)*
+  - [x] Create `src/services/metadata/venue_overrides.py`:
+    - `class VenueOverrideError(Exception)` — raised on a malformed header (the one hard-fail; everything else degrades to a skipped row).
+    - `load_venue_overrides(path: Path) -> dict[str, str]` — **pure parse** (the only I/O is reading the file; no DB, no clock, no network). Behavior:
+      - Missing file ⇒ return `{}` (overrides are optional; a bare-header or absent file must never break an import). [AC4]
+      - Read with `encoding="utf-8-sig"` (strip BOM) and `newline=""`; use `csv.reader`.
+      - Validate the header row: each cell `.strip().lower()` must equal exactly `["ticker", "venue"]`, else raise `VenueOverrideError` with a clear message. [AC1, AC4]
+      - Per data row: `ticker = row[0].strip().upper()`, `venue = row[1].strip().upper()`. Skip a row when `ticker` is blank, `venue` is blank, or `venue == NA_SENTINEL` (import `NA_SENTINEL` from `src.models.instrument_metadata`) — a `debug`/`warning` log, not an error. Ragged/short rows are skipped defensively. [AC4]
+      - Duplicate ticker ⇒ **last wins** (deterministic); optionally `warning`-log the shadowed value.
+      - Return `{ticker: venue}`.
+    - `class VenueOverrideMergeResult(BaseModel)` — `applied: int = 0`, `unchanged: int = 0`, `unmatched: list[str] = []`, with a `total` property (`applied + unchanged + len(unmatched)`). `unmatched` holds override tickers with no `instrument_metadata` row (surfaced, not fabricated).
+    - `merge_venue_overrides(overrides: dict[str, str], repository: SyncInstrumentMetadataRepository, resolved_at: datetime) -> VenueOverrideMergeResult` — iterate `sorted(overrides.items())` (deterministic), call `repository.apply_venue_override(ticker, venue, resolved_at)` (returns `"applied" | "unchanged" | "unmatched"`), and tally into the result. **No clock inside** — `resolved_at` is passed by the caller (mirrors how `InstrumentMetadataService.resolve` stamps `resolved_at` at the service layer, not the repo). [Source: src/services/metadata/instrument_metadata_service.py:34-36,59-62]
+  - [x] Keep every function `< 50` lines, the file `< 500`, fully return-type-annotated (F821 gate). No import from `firstrate` (keep `metadata` decoupled, mirroring `_parse_ipo_date`'s "kept local to avoid coupling metadata→firstrate" note). [Source: src/services/metadata/providers/fmp_provider.py:34-40]
+
+- [x] **Task 3: Repository — `apply_venue_override`** (AC: #2, #3, #4) — *test FIRST (component TDD)*
+  - [x] Add `apply_venue_override(self, ticker: str, venue: str, resolved_at: datetime) -> str` to `SyncInstrumentMetadataRepository` (`src/db/repositories/instrument_metadata_repository_sync.py`). Logic:
+    - `row = self.get_by_ticker(ticker)`; if `None` ⇒ return `"unmatched"` (do NOT fabricate a half-empty row — overrides correct existing rows; a truly-absent ticker is surfaced by the merge result). [AC2, AC4]
+    - **Idempotency guard:** if `row.venue == venue and row.resolution_status == ResolutionStatus.RESOLVED` ⇒ return `"unchanged"` (no mutation, no `resolved_at` write). [AC3]
+    - Else set `row.venue = venue`, `row.resolution_status = ResolutionStatus.RESOLVED`, `row.resolved_at = resolved_at`, `self.session.flush()`, return `"applied"`. [AC2]
+    - Wrap the query/flush in `try/except OperationalError` → `raise DatabaseConnectionError(...)` (mirror `upsert`/`list_by_status`). [Source: src/db/repositories/instrument_metadata_repository_sync.py:68-71,107-110]
+  - [x] Return type is a plain `str` (values `"applied"/"unchanged"/"unmatched"`); annotate fully. Function `< 50` lines. Do **not** touch the async repo (CLI/import sync path only — no web consumer in this story).
+
+- [x] **Task 4: CLI — wire the merge into the import orchestration** (AC: #1, #2, #3) — *test FIRST (TDD)*
+  - [x] In `src/cli/commands/import_data.py`, add a thin helper `_apply_venue_overrides(session: Session, settings) -> None` that: resolves the path from `settings.firstrate.firstrate_venue_overrides_path`; `overrides = load_venue_overrides(Path(path))`; if `overrides` is empty ⇒ return silently (header-only/absent file); else `result = merge_venue_overrides(overrides, SyncInstrumentMetadataRepository(session), datetime.now(timezone.utc))` and print a single Rich summary line (`"Venue overrides: {applied} applied, {unchanged} unchanged, {len(unmatched)} unmatched"`, plus a yellow line listing unmatched tickers if any). Catch `VenueOverrideError` → print one yellow warning and return (skip the merge; bars already imported). [AC1, AC4]
+  - [x] Call `_apply_venue_overrides(session, settings)` in `_run_import` **after** the per-timeframe import loop and **before** `session.commit()` (so the override upserts land in the same transaction as the import, and take precedence over the FMP-resolved rows written during the loop). Do not gate on asset class — the default header-only file makes it a no-op for non-ETF runs. [Source: src/cli/commands/import_data.py:344-361]
+  - [x] Keep the command body within size limits; the merge/format logic lives in `venue_overrides.py`, the CLI helper stays thin.
+
+- [x] **Task 5: CLI — `metadata apply-overrides` refresh subcommand** (AC: #1, #2, #3, #4) — *test FIRST (CliRunner TDD)*
+  - [x] Add `@metadata.command("apply-overrides")` to `src/cli/commands/metadata.py` — the "metadata refresh" path (AC1) so the operator can fill the CSV from the Story 3.2 `metadata unresolved` worklist and apply it **without re-importing bars** (also the seam Story 3.5 relies on for "later receives a venue → becomes backtestable"). It:
+    1. Resolves the path from `get_settings().firstrate.firstrate_venue_overrides_path`.
+    2. `overrides = load_venue_overrides(Path(path))` inside a `try/except VenueOverrideError` → yellow warning + return (AC4).
+    3. Opens `get_sync_session()` inside a `try/except (RuntimeError, DatabaseConnectionError, SQLAlchemyError)` → yellow "Metadata DB not available" warning + return (mirror `unresolved`, AC4).
+    4. On empty `overrides`: print a clear "no overrides to apply" line and return (exit 0). Else `merge_venue_overrides(...)`, `session.commit()`, and render a summary (applied/unchanged/unmatched, with the unmatched tickers listed). [AC1, AC2, AC3]
+  - [x] Reuse the module `console`; `escape()` any DB/CSV-sourced token printed via Rich markup (mirror the Story 3.2 escaping fix). Keep functions `< 50` lines. [Source: src/cli/commands/metadata.py:44-67]
+
+- [x] **Task 6: Git-tracked override file** (AC: #1)
+  - [x] Create `venue_overrides.csv` at the repo root containing exactly the header line `ticker,venue` (no data rows) so the file is git-tracked, present by default, and a no-op until the operator fills it. Add a short leading comment? **No** — the header must be the first row exactly (`ticker,venue`); keep the file header-only.
+
+- [x] **Task 7: Tests** (AC: all)
+  - [x] **Loader/merge unit (`tests/unit/services/metadata/test_venue_overrides.py`, `@pytest.mark.unit`):**
+    - `load_venue_overrides`: valid file → normalized dict (ticker upper, venue upper, whitespace trimmed); BOM header tolerated; missing file → `{}`; malformed header → `VenueOverrideError`; blank-ticker / blank-venue / `N/A`-venue rows skipped; duplicate ticker last-wins; ragged short row skipped. Use `tmp_path`.
+    - `merge_venue_overrides`: with a **fake repository** (records calls, returns scripted `"applied"/"unchanged"/"unmatched"`) assert the tally and that `sorted` order is used and `resolved_at` is threaded through (no clock inside). `VenueOverrideMergeResult.total` correctness.
+  - [x] **Repo component (`tests/component/db/test_instrument_metadata_repository.py`):** seed a `VENUE_UNRESOLVED` row via `_make_metadata`; `apply_venue_override("SPY", "ARCA", ts)` → returns `"applied"`, row now `venue == "ARCA"`, `resolution_status == RESOLVED`, `resolved_at == ts`. Second identical call → `"unchanged"` and `resolved_at` **unchanged** (idempotency). Absent ticker → `"unmatched"`, no row created.
+  - [x] **CLI unit (`tests/unit/cli/commands/test_metadata.py`):** `apply-overrides` — patch `get_settings`, `load_venue_overrides`, `get_sync_session`, and `merge_venue_overrides` (or the repo): populated → exit 0, summary output with counts; empty overrides → "no overrides" line, no merge; malformed file (`load_venue_overrides` raises `VenueOverrideError`) → exit 0, warning, no traceback; DB unconfigured (`get_sync_session` raises `RuntimeError`) → exit 0, warning.
+  - [x] **Import-wiring unit:** a focused test of `_apply_venue_overrides` (patch `load_venue_overrides` + a fake session/repo) covering empty-file no-op, non-empty summary, and `VenueOverrideError` skip. Prefer this over exercising the full `import` command (keeps the test unit-tier, no Nautilus/catalog).
+
+- [x] **Task 8: Verify** (AC: all)
+  - [x] `uv run ruff check .` clean — mind the F401/F821 gate (new imports: `NA_SENTINEL`, `datetime`/`timezone`, `SyncInstrumentMetadataRepository`, `load_venue_overrides`/`merge_venue_overrides`).
+  - [x] `uv run mypy .` — no **new** errors vs the known baseline (6 pre-existing in `ui/explorer`, `ui/backtests` + 2 tests). Fully annotate new functions and the `Literal`/`str` return of `apply_venue_override`.
+  - [x] `make test-unit` green (loader/merge/CLI/import-wiring), `make test-component` green (repo round-trip). No integration/e2e (no engine, no C extensions).
+  - [x] Size limits: files `< 500`, functions `< 50`, classes `< 100`, lines `≤ 100`.
+  - [x] Smoke: `uv run python -m src.cli.main metadata apply-overrides --help` renders; `... metadata apply-overrides` runs against the header-only file → "no overrides to apply" (or a DB-unconfigured warning) with no traceback.
+
+### Review Findings
+
+Adversarial review (Blind Hunter · Edge Case Hunter · Acceptance Auditor). Acceptance Auditor: **PASS** — all 4 ACs satisfied, every "do NOT do here" scope boundary honored. 6 patches applied and re-verified (1889 unit+component pass, ruff+mypy clean); 3 dismissed as documented design.
+
+- [x] [Review][Patch] Malformed-header warning not escaped → Rich markup crash aborts the import (Blind Medium + Auditor). The `VenueOverrideError` message embeds `{header!r}`, whose list repr **always** contains `[...]`; `console.print` with markup enabled would raise `MarkupError`, and the exception propagated out of `_apply_venue_overrides` (called before `session.commit()`) → full-run rollback + traceback. Fixed: `escape(str(exc))` on the import-path warning (mirrors the `metadata.py` twin). Added a bracketed-message regression test. [src/cli/commands/import_data.py:_apply_venue_overrides]
+- [x] [Review][Patch] Unreadable/undecodable override file escapes as a non-`VenueOverrideError` (Edge High + Blind Low) — a non-UTF-8/permission-denied file raised `UnicodeDecodeError`/`OSError`, which neither caller caught → CLI traceback and, in the import path, a swallowed exception that rolled back the whole run. Fixed: `load_venue_overrides` wraps the open/parse in `try/except (OSError, UnicodeDecodeError, csv.Error)` → `raise VenueOverrideError(...)`, so both callers degrade uniformly. Added a non-UTF-8 test. [src/services/metadata/venue_overrides.py:load_venue_overrides]
+- [x] [Review][Patch] Empty (0-byte) file reported as malformed header, not a no-op (Edge Low) — `next(reader, None)` returned `None` → raised. Fixed: `header is None` now returns `{}` (matches the docstring's "absent/empty/header-only → no-op"). Added an empty-file test. [src/services/metadata/venue_overrides.py:load_venue_overrides]
+- [x] [Review][Patch] Venue longer than the `String(20)` column unguarded (Edge Medium) — Postgres would `DataError` (uncaught → full rollback), SQLite silently truncates (env divergence). Fixed: skip a normalized venue longer than `_MAX_VENUE_LEN` (20) at load, alongside the blank/`N/A` skips. Added an oversize-venue test. [src/services/metadata/venue_overrides.py:_merge_row]
+- [x] [Review][Patch] Import-path summary omitted the unmatched-tickers line (Auditor minor) — the CLI `apply-overrides` path listed them; the import path did not. Fixed: `_apply_venue_overrides` now prints the yellow unmatched list (escaped) for parity. Added an unmatched-line test. [src/cli/commands/import_data.py:_apply_venue_overrides]
+- [x] [Review][Patch] Shadowed-duplicate log recorded the winning value, not the dropped one (Blind Low, cosmetic) — `kept=venue` logged the new value; the discarded earlier venue was never recorded. Fixed: `kept=venue, dropped=overrides[ticker]`. [src/services/metadata/venue_overrides.py:_merge_row]
+- [x] [Review][Dismiss] No closed-set validation of the override venue (Edge Medium) — **deliberate, documented** ("No venue validation against a closed set"): overrides exist precisely to supply venues the conservative FMP map can't (ARCA/BATS/IEX…); an allowlist would defeat the purpose and re-introduce guessing. Only empty/`N/A`/oversize are rejected. No change.
+- [x] [Review][Dismiss] DB error mid-merge in the import path is uncaught (Edge Low) — already handled safely by `_run_import`'s existing broad `except Exception` (clean "Fatal error" message + `session.rollback()`, no raw traceback); a dead DB genuinely fails the import. No change.
+- [x] [Review][Dismiss] A benign extra header column rejects the whole file (Edge Low) — by AC1 design ("header exactly `ticker,venue`"). Strict header is intentional. No change.
+
+## Dev Notes
+
+### The core idea (why this story exists)
+Story 3.1 made the FMP-resolved venue authoritative; the conservative venue map (ADR-6) deliberately routes ambiguous labels (notably `AMEX`) to `VENUE_UNRESOLVED` rather than guess. Story 3.2 surfaced those rows as a worklist. Story 3.3 closes the loop: the operator supplies the *correct* venue in a git-tracked `venue_overrides.csv`, and the system merges it into `instrument_metadata` with **precedence** — the override wins over absent/ambiguous provider data and flips the row to `RESOLVED`. This is the only manual write-path into the metadata store (no web write-path — preserves the Phase-1 read-only-explorer stance). Story 3.4 then gates completion on 0 `VENUE_UNRESOLVED`; this story is how the operator drives that count to zero without guessing. [Source: epics.md Epic 3 intro + Story 3.3; architecture.md "no web write-path for venue overrides"]
+
+### Precedence & idempotency — the exact semantics
+- **Precedence (AC2):** the override is operator-asserted truth. The merge sets `venue` and forces `resolution_status = RESOLVED` regardless of what FMP wrote. Descriptive fields (`company_name`, `sector`, …) are **left untouched** — a `RESOLVED` row with `N/A` descriptive gaps is valid (descriptive gaps are an orthogonal dimension in `ResolutionSummary`, not a venue-coverage failure). So even a fully-degraded "unknown to FMP" row (`asset_type=None`, all descriptive `N/A`) becomes backtestable once its venue is asserted. [Source: src/models/instrument_metadata.py:105-152 (three independent metrics)]
+- **Idempotency (AC3):** achieved by a **skip-when-already-at-target** guard in `apply_venue_override` — a row already `(venue == override, status == RESOLVED)` is not written at all, so `resolved_at` does not churn and a second run is a pure no-op. This is why the clock is passed *in* (caller stamps `resolved_at` once per merge) rather than stamped per-row inside the repo: unchanged rows never touch it.
+
+### No venue validation against a closed set (deliberate)
+The whole point of overrides is to supply venues the conservative FMP map could **not** (e.g. `ARCA`, `BATS`, `IEX`, `NYSE-American`). Validating the override venue against a known set would defeat the purpose and re-introduce the "guessing" the map avoids. So the loader normalizes case/whitespace and rejects only the empty string and the `N/A` sentinel (a venue is a real code or nothing — the domain model's `venue_never_na_sentinel` invariant, enforced here at the CSV boundary since the merge writes the ORM directly). [Source: src/models/instrument_metadata.py:96-102; src/services/metadata/venue_map.py:1-14]
+
+### The seam (data + control flow)
+```
+venue_overrides.csv (git-tracked, header ticker,venue, path via FirstRateSettings)
+        │  load_venue_overrides(path)  ← pure parse → {TICKER: VENUE}, skips blanks/N-A, header-validated
+        ▼
+merge_venue_overrides(overrides, repo, resolved_at)   ← orchestration step (CLI), NOT FMPClient
+        │  per ticker: repo.apply_venue_override(ticker, venue, resolved_at)
+        │     absent row → "unmatched"   (surfaced, not fabricated)
+        │     already (venue, RESOLVED) → "unchanged"   (idempotent no-write)
+        │     else set venue + RESOLVED + resolved_at → "applied"
+        ▼
+instrument_metadata rows flip VENUE_UNRESOLVED → RESOLVED  (committed in the import txn / refresh txn)
+```
+Two entry points, one core: the ETF `import` command (merge after the timeframe loop, before commit) and `metadata apply-overrides` (refresh without re-importing bars). Both call the same `merge_venue_overrides`. [Source: src/cli/commands/import_data.py:344-361; src/cli/commands/metadata.py]
+
+### Where the merge lives (AC1 — "not inside FMPClient")
+The merge is import-orchestration, not provider logic. It lives in the CLI layer (`import_data.py` `_run_import`, and the `metadata` group), reading the store the FMP resolution already populated during the import loop. `FMPClient`, `FMPMetadataProvider`, and `InstrumentMetadataService` are **not** touched — the override is a post-resolution correction over the persisted rows, so it must run after the provider has written its (possibly `VENUE_UNRESOLVED`) rows and take precedence over them. [Source: epics.md Story 3.3 AC1]
+
+### Scope boundaries (do NOT do here)
+- **No coverage count / completeness gate** — that is Story 3.4 (`metadata coverage` + the 0-unresolved gate). This story flips rows to `RESOLVED`; it does not compute a pass/fail gate.
+- **No exclude/flag/keep-bars** — Story 3.5. (This merge is the mechanism by which a 3.5-excluded ticker later "receives a venue" and transitions to backtestable, but the exclusion/flag logic itself is 3.5.)
+- **No new DB columns / migrations** — the merge writes existing `instrument_metadata` columns (`venue`, `resolution_status`, `resolved_at`).
+- **No web/API endpoint, no async repo** — CLI sync path only (preserves the read-only-explorer stance).
+- **No changes to the FMP provider, venue map, or resolution service** — the override is a store correction layered on top of their persisted output.
+- **No row fabrication** — an override for a ticker with no metadata row is reported `unmatched`, never invented (a metadata row needs a provider + descriptive context the CSV can't supply).
+
+### Previous-story intelligence
+- **Story 3.1 (done):** `VENUE_UNRESOLVED` ⇔ `venue is None`; the import pipeline is the single writer of `catalog_instruments`; `instrument_metadata` is the source of truth for resolved metadata. The override merge writes `instrument_metadata` (venue + status), and Story 3.1's qualification then reads the now-`RESOLVED` venue to compute `nautilus_id`.
+- **Story 3.2 (done):** `list_by_status(VENUE_UNRESOLVED)` produces the worklist whose `ticker` column keys this CSV; the CLI DB-unconfigured/graceful-degradation idiom (`try/except (RuntimeError, DatabaseConnectionError, SQLAlchemyError)` → one yellow line) and Rich `escape()` of DB/CSV tokens are established there — mirror both. [Source: 3-2 story; src/cli/commands/metadata.py:39-48]
+- **Import wiring (Story 2.4/2.7):** the ETF import already opens a sync session, wires the metadata resolver, runs the timeframe loop, and commits once at the end — the override merge slots in right before that single commit so it is atomic with the import. [Source: src/cli/commands/import_data.py:284-361]
+
+### Testing standards
+- **Unit tier** for the pure loader, the merge core (fake repo), the CLI commands (CliRunner with settings/session/loader patched — no DB, no Nautilus), and the `_apply_venue_overrides` import helper. **Component tier** for the real-repo `apply_venue_override` round-trip over the in-memory SQLite fixture (applied → unchanged idempotency → unmatched). No integration/e2e. [Source: CLAUDE.md Decision Heuristics; ntrader-testing skill]
+- TDD non-negotiable — Red first for `load_venue_overrides`, `merge_venue_overrides`, `apply_venue_override`, and both CLI paths. [Source: development-principles.md]
+- Build ORM rows via the `_make_metadata` kwargs idiom already in the component test; keep markers consistent with siblings. [Source: tests/component/db/test_instrument_metadata_repository.py:48-70]
+
+### Git intelligence
+Scope precedent: Epic-3 stories committed as `feat(epic3): story 3-N — …`. Subject here: `feat(epic3): story 3-3 — venue_overrides.csv merge with precedence`. No AI/claude references. Stage then commit in **separate** Bash calls (the bash-guard commit gate rejects a `git add && git commit` one-liner). [Source: CLAUDE.md Commit Format + Editing with Auto-Linter]
+
+### Project Structure Notes
+- **New:** `src/services/metadata/venue_overrides.py` (`VenueOverrideError`, `load_venue_overrides`, `VenueOverrideMergeResult`, `merge_venue_overrides`); `venue_overrides.csv` (repo root, header-only, git-tracked).
+- **Modified:** `src/config.py` (`firstrate_venue_overrides_path`); `src/db/repositories/instrument_metadata_repository_sync.py` (`apply_venue_override`); `src/cli/commands/import_data.py` (`_apply_venue_overrides` + wiring before commit); `src/cli/commands/metadata.py` (`apply-overrides` subcommand).
+- **New tests:** `tests/unit/services/metadata/test_venue_overrides.py`.
+- **Modified tests:** `tests/unit/cli/commands/test_metadata.py` (apply-overrides), `tests/component/db/test_instrument_metadata_repository.py` (apply_venue_override), config test (path default), import-wiring unit test (co-locate with existing import tests).
+
+### References
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-3.3] — story statement + 3 acceptance criteria; FR22, FR23
+- [Source: src/config.py:147-163] — `FirstRateSettings` (where the override path setting belongs)
+- [Source: src/db/repositories/instrument_metadata_repository_sync.py:32-110] — `upsert`/`get_by_ticker`/`list_by_status` idioms to mirror for `apply_venue_override`
+- [Source: src/services/metadata/instrument_metadata_service.py:34-62] — service-layer `resolved_at` stamping (clock lives above the repo)
+- [Source: src/models/instrument_metadata.py:36-102] — `ResolutionStatus`, `NA_SENTINEL`, `venue_never_na_sentinel` invariant
+- [Source: src/cli/commands/import_data.py:284-361] — import orchestration seam (wire the merge before the single commit)
+- [Source: src/cli/commands/metadata.py:26-67] — `metadata` group + graceful-degradation + Rich-escape idiom to extend with `apply-overrides`
+- [Source: tests/component/db/test_instrument_metadata_repository.py:36-70] — `sync_session` fixture + `_make_metadata` idiom
+
+### Open questions (non-blocking — proceed with the documented default)
+1. **Unmatched-override handling.** Default: report override tickers with no metadata row as `unmatched` (surfaced in the summary), never fabricate a row. Fabricating a minimal row would need a provider + descriptive context the CSV can't supply and would pollute `descriptive_gaps`. Flag if the team wants unmatched overrides to seed placeholder rows.
+2. **Override-file location.** Default: repo-root `venue_overrides.csv` (path via `FirstRateSettings`). A per-catalog override file (e.g. `<catalog>/venue_overrides.csv`) could scope corrections per import, but the metadata store is global (keyed by ticker, not catalog), so a single global file matches the store's grain. Flag if per-catalog scoping is wanted.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8
+
+### Debug Log References
+
+- `uv run pytest tests/unit/services/metadata/test_venue_overrides.py tests/unit/cli/commands/test_metadata.py tests/unit/cli/commands/test_import_data.py tests/component/db/test_instrument_metadata_repository.py` — 98 passed.
+- `uv run pytest tests/unit tests/component` — 1885 passed, 16 skipped (pre-existing report-command skips), no regressions.
+- `uv run ruff check .` — All checks passed. `uv run mypy .` — Success: no issues found in 348 source files.
+
+### Completion Notes List
+
+- **AC1** — `load_venue_overrides` (pure CSV parse, header validated exactly `ticker,venue`, path from `FirstRateSettings.firstrate_venue_overrides_path`) + `merge_venue_overrides` run in the import-orchestration step: `import_data._apply_venue_overrides` (after the timeframe loop, before the single commit) and `metadata apply-overrides` (refresh without re-importing). Neither touches `FMPClient`/the provider/the resolution service.
+- **AC2** — `SyncInstrumentMetadataRepository.apply_venue_override` sets `venue` + forces `resolution_status = RESOLVED` on the existing row (precedence over absent/ambiguous FMP data); no provider call. Descriptive fields untouched (RESOLVED-with-gaps is valid).
+- **AC3** — Idempotent via a skip-when-already-at-target guard: a row already `(venue == override, RESOLVED)` returns `"unchanged"` with no write and no `resolved_at` churn. Clock is passed in by the caller (stamped once per merge), so re-runs are pure no-ops.
+- **AC4** — Malformed header raises `VenueOverrideError` → single yellow warning, merge skipped, in-flight import preserved. Missing file → silent `{}`. Blank-ticker / blank-venue / `N/A`-venue rows skipped. DB-unconfigured (`RuntimeError`/`DatabaseConnectionError`/`SQLAlchemyError`) → one yellow "Metadata DB not available" line, no traceback (mirrors Story 3.2).
+- **Design** — override venue is operator-asserted truth (no closed-set validation — that would re-introduce guessing); unmatched overrides are surfaced, never fabricated into half-empty rows. `venue_overrides.csv` created header-only at repo root (git-tracked, default no-op).
+- **Scope respected** — no coverage/gate (3.4), no exclude/flag (3.5), no new columns/migrations, no async/web path, no changes to provider/venue-map/resolution service.
+
+### Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-13 | Story 3.3 drafted (SM). Status → ready-for-dev. |
+| 2026-07-13 | Implemented pure loader + merge core, `apply_venue_override` repo method, config path, import-orchestration wiring + `metadata apply-overrides` refresh subcommand, git-tracked `venue_overrides.csv` (TDD). Gates green (ruff, mypy, 1885 pass). Status → review. |
+| 2026-07-13 | Code review (3 adversarial layers; Auditor PASS on all 4 ACs). Applied 6 patches (import-path `escape()` markup-crash fix, file-read error → `VenueOverrideError` uniform degradation, empty-file no-op, oversize-venue skip, import-path unmatched line, shadowed-dup log); dismissed 3 as documented design. 1889 unit+component pass, ruff+mypy clean. Status → done. |
+
+### File List
+
+- `src/config.py` (modified — `firstrate_venue_overrides_path`)
+- `src/services/metadata/venue_overrides.py` (new — `VenueOverrideError`, `load_venue_overrides`, `VenueOverrideMergeResult`, `merge_venue_overrides`)
+- `src/db/repositories/instrument_metadata_repository_sync.py` (modified — `apply_venue_override`, `datetime` import)
+- `src/cli/commands/import_data.py` (modified — `_apply_venue_overrides` + wiring before commit, `Settings` type import)
+- `src/cli/commands/metadata.py` (modified — `apply-overrides` subcommand + `_render_override_summary`)
+- `venue_overrides.csv` (new — repo-root, header-only, git-tracked)
+- `tests/unit/services/metadata/test_venue_overrides.py` (new — loader + merge)
+- `tests/unit/cli/commands/test_metadata.py` (modified — `apply-overrides` CLI)
+- `tests/unit/cli/commands/test_import_data.py` (modified — `_apply_venue_overrides` wiring)
+- `tests/component/db/test_instrument_metadata_repository.py` (modified — `apply_venue_override` round-trip)

--- a/_bmad-output/implementation-artifacts/3-4-venue-coverage-report-and-completeness-gate.md
+++ b/_bmad-output/implementation-artifacts/3-4-venue-coverage-report-and-completeness-gate.md
@@ -1,0 +1,195 @@
+# Story 3.4: Venue Coverage Report & Completeness Gate
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the operator,
+I want a deterministic `metadata coverage` CLI report plus a completeness gate,
+so that I can answer "is any ticker missing a venue?" authoritatively, and the system refuses to declare the ETF universe complete until venue coverage is 100% — with no venue ever inferred or guessed to satisfy the gate.
+
+## Acceptance Criteria
+
+1. **Given** the `metadata coverage` CLI subcommand, **When** it runs, **Then** it reports current venue coverage (a per-status breakdown + a coverage percentage) and the exact count of `resolution_status = VENUE_UNRESOLVED` rows, backed by a single indexed grouped-count query over `ix_instrument_metadata_resolution_status` (O(1) w.r.t. row count — no full-table scan, no per-row Python loop over the store).
+2. **Given** any ticker still has `resolution_status = VENUE_UNRESOLVED`, **When** the completeness gate is evaluated, **Then** the gate reports **FAIL** (the ETF universe is NOT marked complete) and no venue is inferred or guessed to satisfy it; with `metadata coverage --gate`, the process exits non-zero (exit code 1) so the gate is scriptable in CI/automation.
+3. **Given** 0 rows with `resolution_status = VENUE_UNRESOLVED`, **When** the completeness gate is evaluated, **Then** the gate reports **PASS** (venue coverage = 100%); with `metadata coverage --gate` the process exits 0.
+4. **Given** the metadata DB is unconfigured (`DATABASE_URL` unset) or unreachable, **When** the subcommand runs, **Then** it degrades gracefully with a single clear warning (no traceback), mirroring the existing `metadata unresolved` DB-unconfigured handling. Under `--gate` a DB that cannot be evaluated exits non-zero (the gate is NOT silently treated as passing).
+
+## Tasks / Subtasks
+
+- [x] **Task 1: Repository — grouped count by resolution status** (AC: #1) — *write the test in `tests/component/db/test_instrument_metadata_repository.py` FIRST (TDD Red→Green)*
+  - [x] Add `count_by_status(self) -> dict[ResolutionStatus, int]` to `src/db/repositories/instrument_metadata_repository_sync.py`: `select(InstrumentMetadata.resolution_status, func.count()).group_by(InstrumentMetadata.resolution_status)`, returning `{status: count for status, count in rows}`. The `group_by` on the indexed `resolution_status` column is served by `ix_instrument_metadata_resolution_status` — a single grouped index scan, O(distinct statuses) = O(1) w.r.t. row count, NOT a full-table scan and NOT a Python-side count. Statuses with no rows are simply absent from the dict (callers use `.get(status, 0)`). [Source: src/db/repositories/instrument_metadata_repository_sync.py:87-111 (`list_by_status` idiom); src/db/models/instrument_metadata.py:71 (index)]
+  - [x] Import `func` from `sqlalchemy` at module top (already imports `select`). Translate `OperationalError → DatabaseConnectionError` inside the method (mirror `list_by_status`/`upsert`) so the CLI can degrade gracefully. Keep the function `< 50` lines, fully return-type-annotated (F821 gate). [Source: src/db/repositories/instrument_metadata_repository_sync.py:108-111]
+  - [x] Do **not** touch the async repository — this gate is a sync CLI path only; no web/API consumer exists in this story.
+
+- [x] **Task 2: Pure coverage aggregate** (AC: #1, #2, #3) — *tests FIRST (TDD)*
+  - [x] Add a frozen dataclass `VenueCoverage` (plus a `from_counts` classmethod) in a new `src/services/metadata/coverage_report.py` — the domain-facing coverage math lives beside the other metadata services (like `unresolved_report.py`), pure and unit-testable without Click or a DB. Fields: `resolved: int`, `venue_unresolved: int`, `unresolved: int`.
+    - `from_counts(counts: dict[ResolutionStatus, int]) -> VenueCoverage`: read each status via `counts.get(status, 0)` (absent ⇒ 0).
+    - `decided` property = `resolved + venue_unresolved` (the rows resolution has reached a venue verdict on — the coverage denominator).
+    - `total` property = `resolved + venue_unresolved + unresolved` (all metadata rows).
+    - `coverage_pct` property = `100.0` when `decided == 0` (vacuously complete — nothing undecided), else `resolved / decided * 100`. Denominator is `decided`, NOT `total`, so the gate identity holds exactly: `is_complete ⟺ coverage_pct == 100.0` (AC3's "(venue coverage = 100%)"). `UNRESOLVED` rows (never-attempted) are surfaced separately by the CLI, not folded into the percentage — folding them would break the gate identity and misreport "not attempted" as "failed to resolve venue". [Source: epics.md Story 3.4 AC3; Dev Notes "Why the denominator is `decided`, not `total`"]
+    - `is_complete` property (the gate) = `venue_unresolved == 0`. This is the ONLY gate condition (AC2/AC3 key strictly on `VENUE_UNRESOLVED`). Do NOT gate on `UNRESOLVED` — a never-attempted row is a resolution-not-run signal, not a venue that "couldn't be resolved"; gating on it would conflate the two states the enum deliberately separates. [Source: src/models/instrument_metadata.py:36-46; epics.md FR24]
+  - [x] Keep the aggregate pure (no I/O, no clock), fully annotated, `< 100` lines for the class. Use `from src.models.instrument_metadata import ResolutionStatus`.
+
+- [x] **Task 3: CLI — `metadata coverage` subcommand + `--gate` flag** (AC: #1, #2, #3, #4) — *tests FIRST (TDD, CliRunner)*
+  - [x] Add `@metadata.command("coverage")` with a `--gate/--no-gate` boolean flag (default `--no-gate`) to `src/cli/commands/metadata.py`. Docstring: report venue coverage + completeness verdict; `--gate` makes the process exit non-zero when the universe is not complete (for CI). [Source: src/cli/commands/metadata.py:41-59 (`unresolved` idiom); src/cli/commands/reproduce.py:58 (`sys.exit(1)` precedent)]
+  - [x] The command body:
+    1. Open a sync session via `get_sync_session()` inside a `try/except (RuntimeError, DatabaseConnectionError, SQLAlchemyError)` that prints a single yellow warning line (mirror `unresolved`). **On the gate path (`--gate`) a DB error must NOT be treated as passing:** after printing the warning, `sys.exit(2)` (distinct from the gate-FAIL code 1) so automation sees "could not evaluate" ≠ "passed". Without `--gate`, return cleanly (exit 0) after the warning (AC4). [Source: src/cli/commands/metadata.py:54-58]
+    2. `counts = SyncInstrumentMetadataRepository(session).count_by_status()` → `coverage = VenueCoverage.from_counts(counts)`.
+    3. Delegate rendering to a pure helper `_render_coverage(coverage) -> None`: a Rich `Table` (columns **Status**, **Count**) with one row per `ResolutionStatus` (RESOLVED / VENUE_UNRESOLVED / UNRESOLVED, showing `.get→0`), a total line, a `Venue coverage: {pct:.1f}% ({resolved}/{decided} decided)` line, an explicit `Unresolved venues (VENUE_UNRESOLVED): {n}` line, a `Not yet attempted (UNRESOLVED): {n}` line when `> 0`, and a bold verdict line: `[green]✓ COMPLETE — venue coverage 100% (gate PASS)[/green]` or `[red]✗ INCOMPLETE — {n} ticker(s) VENUE_UNRESOLVED (gate FAIL)[/red]`. When `total == 0`, print a clear "no metadata rows yet — nothing to gate" note (gate still PASS vacuously, but flagged). (AC1, AC2, AC3)
+    4. After rendering, if `--gate` and `not coverage.is_complete`: `sys.exit(1)` (AC2). Otherwise return (exit 0) (AC3). Keep the render side-effect-free of exit logic — the command decides the exit code, the helper only prints (unit-testable without SystemExit). [Source: CLAUDE.md size limits; Dev Notes "Gate exit codes"]
+  - [x] Keep every function `< 50` lines and the file `< 500`. `sys` import at module top (add `import sys`). No new settings, no migration, no network/provider call. [Source: CLAUDE.md Foundational Rules]
+
+- [x] **Task 4: Unit tests** (AC: #1, #2, #3, #4)
+  - [x] **Coverage aggregate (`tests/unit/services/metadata/test_coverage_report.py`, `@pytest.mark.unit`):**
+    - All resolved (`{RESOLVED: 10}`) → `coverage_pct == 100.0`, `is_complete is True`, `decided == 10`, `total == 10`.
+    - Mixed with unresolved venue (`{RESOLVED: 8, VENUE_UNRESOLVED: 2}`) → `coverage_pct == 80.0`, `is_complete is False`, `venue_unresolved == 2`.
+    - `UNRESOLVED` excluded from pct but counted in total (`{RESOLVED: 5, UNRESOLVED: 5}`) → `coverage_pct == 100.0` (decided=5), `is_complete is True` (no VENUE_UNRESOLVED), `total == 10`, `unresolved == 5` — proves never-attempted rows don't fail the gate or dilute the percentage.
+    - Empty (`{}`) → `total == 0`, `decided == 0`, `coverage_pct == 100.0`, `is_complete is True` (vacuous). Absent statuses default to 0.
+    - Gate identity: for a case with `VENUE_UNRESOLVED == 0`, assert `is_complete is True and coverage_pct == 100.0`; for `VENUE_UNRESOLVED > 0`, assert `is_complete is False and coverage_pct < 100.0`.
+  - [x] **CLI (`tests/unit/cli/commands/test_metadata.py`, `CliRunner`, `@pytest.mark.unit`):** patch `get_sync_session` + `SyncInstrumentMetadataRepository` (mirror `_patch_session_and_repo`). Set `mock_repo.return_value.count_by_status.return_value = {...}`.
+    - **Complete, no flag:** counts `{RESOLVED: 3}` → exit 0, output contains `100.0%`, `COMPLETE`, `gate PASS`.
+    - **Incomplete, no flag:** counts `{RESOLVED: 2, VENUE_UNRESOLVED: 1}` → exit 0 (report-only, no flag), output contains `INCOMPLETE`, `gate FAIL`, `66.7%`, and `1 ticker(s) VENUE_UNRESOLVED`.
+    - **Incomplete + `--gate`:** same counts + `["coverage", "--gate"]` → **exit code 1**, output still shows FAIL (AC2).
+    - **Complete + `--gate`:** `{RESOLVED: 3}` + `--gate` → exit 0 (AC3).
+    - **DB unconfigured, no flag:** `get_sync_session.__enter__` raises `RuntimeError(...)` → exit 0, `result.exception is None`, output contains `Metadata DB not available` (AC4).
+    - **DB unconfigured + `--gate`:** same → **exit code 2** (could-not-evaluate ≠ pass), warning present, no traceback (AC4).
+    - **DB query error + `--gate`:** `count_by_status.side_effect = OperationalError(...)` → exit code 2, warning present (query-time failure under the lazy session).
+  - [x] **Render helper (`TestRenderCoverage`, `capsys`, no CliRunner):** direct `_render_coverage(VenueCoverage.from_counts({RESOLVED:2, VENUE_UNRESOLVED:1}))` asserts the status counts, `66.7%`, and the FAIL verdict text; a complete case asserts PASS; an empty case asserts the "no metadata rows" note.
+
+- [x] **Task 5: Component test — real sync repo grouped count** (AC: #1)
+  - [x] In `tests/component/db/test_instrument_metadata_repository.py` add `test_count_by_status_groups_and_counts`: seed via `_make_metadata`/`upsert` a mix (e.g. 2× `RESOLVED`, 1× `VENUE_UNRESOLVED`, 1× `UNRESOLVED`), call `count_by_status()`, assert `== {ResolutionStatus.RESOLVED: 2, ResolutionStatus.VENUE_UNRESOLVED: 1, ResolutionStatus.UNRESOLVED: 1}`. Add `test_count_by_status_empty_returns_empty_dict`: no rows → `{}`. Reuse the file's `sync_session` fixture + `_CREATE_TABLE_SQL`. [Source: tests/component/db/test_instrument_metadata_repository.py:236-279 (`list_by_status` round-trip precedent)]
+
+- [x] **Task 6: Verify** (AC: all)
+  - [x] `uv run ruff check .` clean — mind the F401/F821 import gate (new `func`, `sys`, `VenueCoverage` imports).
+  - [x] `uv run mypy .` — no **new** errors vs the known baseline (`reference_mypy_baseline_debt`: 6 pre-existing in `ui/explorer`, `ui/backtests` + 2 tests). Fully annotate new functions/dataclass.
+  - [x] `make test-unit` green (coverage aggregate + CLI + render deltas, no regressions). `make test-component` green for the new repo test.
+  - [x] Size limits: files `< 500` lines, functions `< 50`, classes `< 100`, line length `≤ 100`.
+  - [x] Smoke: covered by `CliRunner` tests (help/registration + exit codes 0/1/2 + DB-unconfigured warning); the harness permission mode blocks the live `python -m src.cli.main` subprocess, so the identical command paths are exercised via `CliRunner.invoke` instead.
+
+### Review Findings
+
+Adversarial review (Blind Hunter · Edge Case Hunter · Acceptance Auditor). Acceptance Auditor: **PASS** — all 4 ACs satisfied, no scope violations, size limits respected. 2 patches applied + re-verified; 1 dismissed.
+
+- [x] [Review][Patch] Coverage line rounds to "100.0%" while the verdict is gate FAIL (blind+edge, Med) — `f"{coverage_pct:.1f}"` collapses 99.95–99.99…% onto "100.0%", so e.g. `{RESOLVED: 9999, VENUE_UNRESOLVED: 1}` printed `Venue coverage: 100.0%` right next to `✗ INCOMPLETE … (gate FAIL)`. `is_complete` (exact float) drove the correct exit code, so no functional gate impact — but the operator/CI line was self-contradictory. Fixed: `_render_coverage` clamps the *displayed* percentage to `99.9%` when `not is_complete` and the value would round to ≥100.0, so the number can never read 100.0% while the verdict is FAIL. Added a render test at `RESOLVED=9999, VENUE_UNRESOLVED=1`. [src/cli/commands/metadata.py:_render_coverage]
+- [x] [Review][Patch] Un-caveated green "COMPLETE / 100%" when `decided == 0` but `total > 0` (blind+edge, Low) — the "vacuous PASS" transparency note keyed on `total == 0`, so a store holding only never-attempted `UNRESOLVED` rows (resolution never ran) rendered `Venue coverage: 100.0% (0/0 decided)` + green `✓ COMPLETE` with no caveat, even though those tickers have no venue. Per-AC the gate correctly keys strictly on `VENUE_UNRESOLVED` (Auditor confirmed AC2/AC3 compliant; open-question #1 default), and the raw `UNRESOLVED` count is already surfaced — this was purely a transparency gap in the code's own caveat. Fixed: the note now also fires on `decided == 0 and total > 0` ("resolution has not run on any row; PASS is vacuous"). Gate semantics unchanged. Added a render test for the pure-`UNRESOLVED` case. [src/cli/commands/metadata.py:_render_coverage]
+- [x] [Review][Dismiss] `count_by_status` dict keys deserialize as `str` not enum → all `.get(ResolutionStatus.X)` miss → gate silently a no-op (blind, Low-conditional) — false positive. The `resolution_status` column is a `sa.Enum(ResolutionStatus)`, whose result processor maps the stored value back to the enum member on both SQLite and Postgres; the component test `test_count_by_status_groups_and_counts` asserts the exact enum-keyed map over real SQLite and passes. Doubly robust: `ResolutionStatus` is a `str`-enum with `name == value`, so even a raw-string key would satisfy `.get(ResolutionStatus.X)` (equal value and equal hash). No change needed.
+
+## Dev Notes
+
+### The core idea (why this story exists)
+Epic 3 gates ETF-universe completion on **100% venue coverage with no inferred venues**. Story 3.1 made the FMP-resolved venue authoritative; 3.2 gave the operator the worklist (`metadata unresolved`); 3.3 let them fix it (`venue_overrides.csv` merge). Story 3.4 is the **authoritative answer + the hard gate**: a single indexed count that says "is any ticker missing a venue?" and a PASS/FAIL verdict the operator (and CI, via `--gate`) can trust. The gate never guesses a venue to make itself pass — a `VENUE_UNRESOLVED` row is a FAIL, full stop (ADR-6 conservative venue map: ambiguous labels stay unresolved rather than get guessed). [Source: epics.md Epic 3 intro + FR24; architecture.md venue-correctness risk]
+
+### Why the denominator is `decided`, not `total`
+The enum has three states (`src/models/instrument_metadata.py:36-46`):
+- **RESOLVED** — venue known (backtestable).
+- **VENUE_UNRESOLVED** — resolution ran, venue could not be determined (the gate blocker).
+- **UNRESOLVED** — resolution never attempted for this row (transient; should not persist post-import).
+
+`coverage_pct = resolved / (resolved + venue_unresolved)` deliberately excludes `UNRESOLVED`, so the gate identity holds **exactly**: `is_complete ⟺ coverage_pct == 100.0` (AC3 states 0 `VENUE_UNRESOLVED` ⟹ "venue coverage = 100%"). Folding `UNRESOLVED` into the denominator would (a) make coverage < 100% even with 0 `VENUE_UNRESOLVED`, contradicting AC3, and (b) misreport "resolution not yet run" as "venue could not be resolved" — two states the schema keeps separate on purpose. `UNRESOLVED` rows are still **surfaced** on their own report line (transparency), just kept out of the ratio and the gate. Post-import they're ~always 0, so in practice `decided == total`. [Source: epics.md Story 3.4 AC1–AC3]
+
+### Gate exit codes (`--gate`)
+- **exit 0** — universe complete (0 `VENUE_UNRESOLVED`), or report-only run (`--no-gate`, always 0 regardless of verdict).
+- **exit 1** — `--gate` and universe INCOMPLETE (≥1 `VENUE_UNRESOLVED`). The scriptable FAIL.
+- **exit 2** — `--gate` and the DB could not be evaluated (unset/unreachable). A gate that can't read the store must **not** report PASS — an unevaluable gate is distinct from a passing one, so CI treats it as an error, not a green light. Without `--gate`, DB-unconfigured is a plain warning + exit 0 (mirrors `metadata unresolved` AC4). [Source: src/cli/commands/metadata.py:54-58; src/cli/commands/reproduce.py:58 (`sys.exit(1)`); CLAUDE.md "never touch live data" — this is read-only over the local cache]
+
+### The seam (data + control flow)
+```
+instrument_metadata (cache table; populated by Epic-1 resolution + Story 3.1 import + Story 3.3 overrides)
+        │  grouped indexed COUNT(*) GROUP BY resolution_status   ← ix_instrument_metadata_resolution_status
+        ▼
+  count_by_status()  →  {RESOLVED: n, VENUE_UNRESOLVED: m, UNRESOLVED: k}
+        │
+  VenueCoverage.from_counts(...)   ← pure: coverage_pct, is_complete (gate)
+        ▼
+  metadata coverage [--gate]  (CLI, this story)
+        │  _render_coverage: Rich table + pct + PASS/FAIL verdict
+        ▼  exit 0 / 1 / 2   (only under --gate)
+```
+Read-only over the local cache — no network, no provider call, no write. [Source: architecture.md two-table boundary; src/db/models/instrument_metadata.py:59-71]
+
+### Scope boundaries (do NOT do here)
+- **No venue inference/guessing** — a `VENUE_UNRESOLVED` row is a FAIL; never fabricate a venue to pass the gate (AC2, ADR-6).
+- **No exclude/flag/keep-bars enumeration of the backtestable universe** — that is Story 3.5. This story counts + gates; it does not enumerate or mutate which tickers enter a backtest.
+- **No override load/merge** — that is Story 3.3 (`apply-overrides`, already done). This story reads the post-merge state.
+- **No new DB columns / migrations / settings** — the index and `resolution_status` enum already exist.
+- **No async/web endpoint** — CLI sync path only. Do not touch the async repo or add an API route.
+- **No changes to the FMP provider, venue map, or resolution service** — all `done`; this story only *reads* their persisted output.
+
+### Design decision — grouped count vs. per-status count
+A single `COUNT(*) GROUP BY resolution_status` returns all three counts in one indexed query — strictly cheaper than three separate `COUNT WHERE status = ?` calls, and it yields the whole coverage picture (numerator, denominator, and the `UNRESOLVED` line) at once. Both forms are "backed by the index"; the grouped form is the natural fit for a *coverage* report (which needs the breakdown), where 3.2's `list_by_status` was the natural fit for a *worklist*. [Source: src/db/models/instrument_metadata.py:71]
+
+### Design decision — verdict math in `services/metadata`, gate exit in the CLI
+`VenueCoverage` (pure aggregate: pct + `is_complete`) lives in `src/services/metadata/coverage_report.py` beside `unresolved_report.py`, unit-testable with no Click/DB. The CLI command owns only the exit-code decision (`sys.exit`) and rendering, so the gate *logic* is tested without `SystemExit` and the exit *wiring* is tested via `CliRunner`. Matches the project's "pure logic → unit tier" heuristic and the 3.2 precedent (`unresolved_reason` pure; CLI thin). [Source: CLAUDE.md Decision Heuristics; src/services/metadata/unresolved_report.py]
+
+### Previous-story intelligence
+- **Story 3.2 (done)** added the `metadata` Click group + `list_by_status` (indexed filter). This story adds `coverage` to the same group and `count_by_status` (indexed grouped count) beside it — same index, same graceful-degradation idiom (`(RuntimeError, DatabaseConnectionError, SQLAlchemyError)` → yellow warning; query-time failures surface inside the lazy session, so the `except` must wrap the query, not just the `with`-entry). [Source: 3-2 story Review Findings; src/cli/commands/metadata.py:49-58]
+- **Story 3.3 (done)** made overrides flip rows to `RESOLVED`, so after `apply-overrides` a re-run of `metadata coverage` should show coverage climbing toward 100%. The gate reads the post-merge truth. [Source: src/db/repositories/instrument_metadata_repository_sync.py:113-147]
+- **`ix_instrument_metadata_resolution_status` (Story 1.2, done)** indexes `resolution_status` — the grouped count is an index scan. [Source: src/db/models/instrument_metadata.py:71]
+
+### Testing standards
+- **Unit tier** for the pure `VenueCoverage` aggregate, the `_render_coverage` helper, and the CLI command (`CliRunner` with `get_sync_session`/repo patched — no DB, no Nautilus). **Component tier** for the real-repo `count_by_status` grouped round-trip over the in-memory SQLite fixture. No integration/e2e — no engine, no C extensions. [Source: CLAUDE.md Decision Heuristics; ntrader-testing skill]
+- TDD non-negotiable — Red first for `count_by_status`, `VenueCoverage`, and the CLI command. [Source: development-principles.md]
+- Build ORM rows in component tests via the `_make_metadata` kwargs idiom; keep `@pytest.mark.unit` / component markers consistent with siblings.
+
+### Project Structure Notes
+- **New:** `src/services/metadata/coverage_report.py` (`VenueCoverage`).
+- **Modified:** `src/cli/commands/metadata.py` (`coverage` subcommand + `_render_coverage` + `import sys`), `src/db/repositories/instrument_metadata_repository_sync.py` (`count_by_status`, `func` import).
+- **New tests:** `tests/unit/services/metadata/test_coverage_report.py`.
+- **Modified tests:** `tests/unit/cli/commands/test_metadata.py` (`coverage` CLI + render + registration), `tests/component/db/test_instrument_metadata_repository.py` (`count_by_status` round-trip).
+
+### References
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-3.4] — story statement + 3 acceptance criteria; FR24
+- [Source: _bmad-output/planning-artifacts/epics.md:127] — "B-tree index powers the O(1) completeness gate"
+- [Source: src/db/repositories/instrument_metadata_repository_sync.py:87-111] — `list_by_status` (indexed filter + OperationalError translation) to mirror for `count_by_status`
+- [Source: src/db/models/instrument_metadata.py:59-71] — `resolution_status` enum column + `ix_instrument_metadata_resolution_status` index
+- [Source: src/models/instrument_metadata.py:36-46] — the three `ResolutionStatus` states
+- [Source: src/cli/commands/metadata.py:41-77] — `metadata` group + `unresolved` command + render-helper idiom to mirror
+- [Source: src/cli/commands/reproduce.py:58] — `sys.exit(1)` precedent for non-zero CLI exit
+- [Source: tests/unit/cli/commands/test_metadata.py:42-49] — `_patch_session_and_repo` idiom for CLI unit tests
+- [Source: tests/component/db/test_instrument_metadata_repository.py:236-294] — `list_by_status` round-trip precedent for the grouped-count test
+
+### Open questions (non-blocking — proceed with the documented default)
+1. **Coverage denominator.** Default: `decided = resolved + venue_unresolved` (excludes never-attempted `UNRESOLVED`), so `is_complete ⟺ coverage_pct == 100%` per AC3. `UNRESOLVED` is surfaced on its own line but not in the ratio. Flag if the team wants `total` as the denominator (would decouple the gate identity from 100%).
+2. **DB-unevaluable exit code under `--gate`.** Default: exit 2 (distinct from FAIL=1), so CI never reads "couldn't reach DB" as PASS. Flag if a single non-zero code (1 for any non-pass) is preferred.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8
+
+### Debug Log References
+
+- `uv run pytest tests/unit/services/metadata/test_coverage_report.py tests/unit/cli/commands/test_metadata.py tests/component/db/test_instrument_metadata_repository.py` — 50 passed (6 coverage-aggregate + CLI/render deltas + 3 new `count_by_status` repo round-trips).
+- `uv run pytest tests/unit tests/component` — 1908 passed, 16 skipped (pre-existing report-command skips), no regressions.
+- `uv run ruff check .` — All checks passed. `uv run mypy .` — Success: no issues found in 350 source files.
+
+### Completion Notes List
+
+- **AC1** — `SyncInstrumentMetadataRepository.count_by_status()` (single indexed `COUNT(*) GROUP BY resolution_status`, O(distinct statuses)) + `metadata coverage` CLI report a per-status breakdown, a coverage percentage, and the exact `VENUE_UNRESOLVED` count. `VenueCoverage` (pure) does the math.
+- **AC2** — Any `VENUE_UNRESOLVED` row → verdict INCOMPLETE / "gate FAIL"; no venue is inferred. `metadata coverage --gate` exits 1 (scriptable). Report-only (`--no-gate`) always exits 0 regardless of verdict.
+- **AC3** — 0 `VENUE_UNRESOLVED` → COMPLETE / "gate PASS", coverage 100.0% (denominator is `decided`, so the gate identity `is_complete ⟺ coverage_pct == 100` holds exactly); `--gate` exits 0.
+- **AC4** — DB unset/unreachable → single yellow warning, no traceback. Under `--gate` an unevaluable gate exits 2 (distinct from FAIL=1) so CI never reads "unreachable" as "passed"; without `--gate` it exits 0.
+- **Design** — coverage math (`VenueCoverage`) placed in `src/services/metadata/coverage_report.py` (pure, beside `unresolved_report.py`); the CLI owns only rendering + the exit-code decision. `UNRESOLVED` (never-attempted) rows are surfaced on their own report line but excluded from the ratio and the gate — kept distinct from `VENUE_UNRESOLVED` (couldn't-resolve).
+- **Scope respected** — no venue inference, no exclude/flag/keep-bars enumeration (3.5), no override load/merge (3.3), no new columns/migrations/settings, no async/web path, no changes to provider/venue-map/resolution service. Read-only over the local cache table.
+- **Smoke** — the harness permission mode blocks launching `python -m src.cli.main`; the identical command paths (help/registration, exit 0/1/2, DB-unconfigured) are covered by `CliRunner` unit tests.
+
+### Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-13 | Story 3.4 drafted (SM). Status → ready-for-dev. |
+| 2026-07-13 | Implemented `count_by_status` (indexed grouped count), pure `VenueCoverage` aggregate, `metadata coverage [--gate]` CLI + `_render_coverage`; unit + component tests (TDD). Gates green (ruff, mypy, 1908 pass). Status → review. |
+| 2026-07-13 | Code review (3 adversarial layers; Auditor PASS on all 4 ACs). Applied 2 patches (display-percent clamp so it can't read 100.0% while FAIL; vacuous-PASS caveat now fires on `decided==0` not just `total==0`) + 2 render tests; dismissed 1 false positive (enum-key round-trip, disproven by component test). 1910 unit+component pass, ruff+mypy clean. Status → done. |
+
+### File List
+
+- `src/db/repositories/instrument_metadata_repository_sync.py` (modified — `count_by_status`, `func` import)
+- `src/services/metadata/coverage_report.py` (new — pure `VenueCoverage` aggregate)
+- `src/cli/commands/metadata.py` (modified — `coverage` subcommand + `_render_coverage` + `sys`/`VenueCoverage` imports)
+- `tests/unit/services/metadata/test_coverage_report.py` (new — coverage/gate math)
+- `tests/unit/cli/commands/test_metadata.py` (modified — `coverage` CLI + render + registration)
+- `tests/component/db/test_instrument_metadata_repository.py` (modified — `count_by_status` round-trip + empty + error translation)

--- a/_bmad-output/implementation-artifacts/3-5-exclude-and-flag-non-backtestable-tickers.md
+++ b/_bmad-output/implementation-artifacts/3-5-exclude-and-flag-non-backtestable-tickers.md
@@ -1,0 +1,186 @@
+# Story 3.5: Exclude & Flag Non-Backtestable Tickers
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the system,
+I want tickers without a resolved venue excluded from the backtestable universe and flagged non-backtestable, while their imported bars are kept,
+so that an unresolved-venue ticker never silently enters a backtest and its data is never lost or orphaned.
+
+## Acceptance Criteria
+
+1. **Given** a ticker with `resolution_status = VENUE_UNRESOLVED`, **When** the backtestable universe is enumerated, **Then** the ticker is **excluded** from it and **flagged** non-backtestable — the enumeration is a live derivation over `instrument_metadata.resolution_status` (backtestable ⟺ `RESOLVED`), so no venue is guessed to admit it and a stale/provisional `catalog_instruments.nautilus_id` never sneaks it back in.
+2. **Given** that same excluded ticker, **When** the catalog is inspected, **Then** its imported Parquet bars are still present (excluded ≠ dropped): this story never deletes a partition, and the `catalog_instruments` row (with its `bar_count_*`) persists, so `metadata backtestable` reports the retained bars as evidence. The Story-3.1 identity-nulling is **intentionally retained** — nulling `nautilus_id` is the exclusion mechanism the backtest path honors (`backtest_loader` gates on `nautilus_id`); the bars stay physically on disk and become reachable again when the venue resolves. (See Review Findings: keeping a provisional id to make bars reachable was tried and reverted because it re-admits guessed-venue tickers to backtests — worse than the benign unreachable-by-id state.)
+3. **Given** that ticker later receives a venue (via the Story 3.3 `venue_overrides.csv` merge, which flips its row to `RESOLVED`), **When** the backtestable universe is re-enumerated, **Then** it transitions to backtestable **without re-importing its bars** — a consequence of the enumeration being derived live from `resolution_status` (the override alone moves it), and its bar counts / date ranges are unchanged.
+4. **Given** the metadata DB is unconfigured (`DATABASE_URL` unset) or unreachable, **When** the `metadata backtestable` report runs, **Then** it degrades gracefully with a single clear warning (no traceback), mirroring the existing `metadata unresolved` / `metadata coverage` DB-unconfigured handling.
+
+## Tasks / Subtasks
+
+- [x] **Task 1: Pure backtestable classifier + flagged-ticker record** (AC: #1, #2) — *write the test in `tests/unit/services/metadata/test_backtestable.py` FIRST (TDD Red→Green)*
+  - [x] Add `src/services/metadata/backtestable.py` — domain-facing, pure, beside `coverage_report.py` / `unresolved_report.py` (no Click, no session, no clock):
+    - `is_backtestable(status: ResolutionStatus) -> bool` = `status == ResolutionStatus.RESOLVED`. This is the ONLY backtestable predicate: `VENUE_UNRESOLVED` (the gate blocker) and `UNRESOLVED` (never attempted) are both non-backtestable. Keying the universe on the *venue verdict* — not on `catalog_instruments.nautilus_id` — is what makes AC1 robust (a kept provisional id can't re-admit an unresolved ticker) and AC3 free (an override flip to `RESOLVED` moves the ticker with no re-qualify, no re-import). [Source: src/models/instrument_metadata.py:36-46; epics.md Story 3.5 AC1/AC3; src/services/metadata/coverage_report.py:60-63 (`is_complete` keys on the same enum)]
+    - `total_bars(instrument: CatalogInstrument) -> int` = sum of the five `bar_count_*` fields (`daily + hourly + minute + 5min + 30min`). Used to *evidence* that an excluded ticker's bars are retained. [Source: src/db/models/catalog_instrument.py:92-106]
+    - A frozen dataclass `NonBacktestableTicker` with `ticker: str` and `bars_retained: int`, plus a `bars_kept: bool` property = `bars_retained > 0`. This is the flag record the CLI renders (a ticker with no `catalog_instruments` row / no bars reports `bars_retained == 0` — fresh unresolved, nothing to lose). [Source: src/services/metadata/coverage_report.py:14-41 (frozen-dataclass idiom)]
+  - [x] Import `from src.models.instrument_metadata import ResolutionStatus` and `from src.db.models.catalog_instrument import CatalogInstrument`. Keep the module `< 100` lines, fully return-type-annotated (F821 gate). No new settings, no I/O.
+
+- [x] **Task 2: ~~Orphan-safety fix in `sync_qualification`~~ — TRIED & REVERTED (AC: #2)**
+  - [x] **This task was implemented, then reverted during code review — see Review Findings.** The plan was to keep the provisional `nautilus_id` when `total_bars(instrument) > 0` (venue unresolved but bars on disk) so the bars stay reachable, per the 3.1 deferred-work note. Code review (Edge Case Hunter, confirmed against `backtest_loader.py:136`) found that `backtest_loader.load_from_catalog` — and `api/rest/explorer.py`, `api/stats_service.py`, `api/chart_bars.py` — gate backtestability **solely on `catalog_instruments.nautilus_id`**, never on `resolution_status`. Keeping a provisional id therefore lets an unresolved-venue ticker **run a backtest under a guessed venue**, violating AC1 ("never silently enter a backtest") and ADR-6 — strictly worse than the orphan it fixes.
+  - [x] **Resolution:** `sync_qualification` is left at its Story 3.1 behavior (null `nautilus_id`/`exchange` on `VENUE_UNRESOLVED`). Nulling is the exclusion mechanism the real backtest path honors; the Parquet is never deleted, so AC2 ("bars present, not dropped") holds — bars are physically retained, just unreachable-by-id until the venue resolves. The true "keep bars reachable AND excluded" fix needs a consumer-honored non-backtestable signal threaded through the loader/explorer/stats/chart — re-deferred to Epic 5 (backtest integration). [Source: deferred-work.md updated 2026-07-13; src/services/firstrate/backtest_loader.py:136-147]
+
+- [x] **Task 3: CLI — `metadata backtestable` report** (AC: #1, #2, #4) — *tests FIRST (TDD, CliRunner)*
+  - [x] Add `@metadata.command("backtestable")` with `--catalog` (`click.option`, default `None` → resolved to `get_settings().firstrate.firstrate_catalog_name`) to `src/cli/commands/metadata.py`. Docstring: enumerate the backtestable universe (RESOLVED-venue tickers) and flag the non-backtestable ones (VENUE_UNRESOLVED), confirming their bars are retained (excluded ≠ dropped). [Source: src/cli/commands/metadata.py:82-112 (`apply-overrides` catalog/settings idiom); src/cli/commands/metadata.py:126-153 (`coverage` option idiom)]
+  - [x] Command body:
+    1. `catalog_name = catalog or get_settings().firstrate.firstrate_catalog_name`.
+    2. Open a sync session inside a `try/except (RuntimeError, DatabaseConnectionError, SQLAlchemyError)` that prints a single yellow `Metadata DB not available — {escape(exc)}` line and returns (exit 0) — mirror `coverage`/`unresolved` (the query runs inside the `with`, since the lazy session surfaces failures at execute time). (AC4)
+    3. `meta_repo = SyncInstrumentMetadataRepository(session)`; `cat_repo = SyncCatalogInstrumentRepository(session)`.
+    4. `backtestable_count = meta_repo.count_by_status().get(ResolutionStatus.RESOLVED, 0)` (indexed grouped count — the backtestable universe size). `unresolved_rows = meta_repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED)` (the flagged set, ordered by ticker).
+    5. Build `flagged: list[NonBacktestableTicker]`: for each unresolved row, `inst = cat_repo.get_by_ticker(catalog_name, row.ticker)`; `bars = total_bars(inst) if inst is not None else 0`; append `NonBacktestableTicker(row.ticker, bars)`.
+  - [x] Delegate rendering to a pure `_render_backtestable(catalog_name: str, backtestable_count: int, flagged: list[NonBacktestableTicker]) -> None` (no exit logic, `capsys`-testable):
+    - When `flagged` is empty: a green `✓ All venue-resolved — backtestable universe = {backtestable_count} ticker(s), 0 non-backtestable.` line.
+    - Otherwise a Rich `Table` (title `Non-backtestable tickers (venue unresolved)`, columns **Ticker**, **Bars retained**) — one escaped row per flagged ticker showing `bars_retained`; then a summary: `Backtestable: {backtestable_count} · Non-backtestable: {len(flagged)} (bars retained, not dropped)`, and an explicit `Bars are kept on disk — resolve each venue in venue_overrides.csv (Story 3.3) to make it backtestable.` hint. Escape all DB-sourced strings (`escape(row.ticker)`) as `_render_unresolved` does. [Source: src/cli/commands/metadata.py:64-79]
+  - [x] Add imports: `SyncCatalogInstrumentRepository`, `NonBacktestableTicker`, `total_bars` (mind the F401/F821 gate). Keep every function `< 50` lines, the file `< 500`. No `sys.exit` here (report-only, always exit 0). No network/provider call. [Source: CLAUDE.md Foundational Rules]
+
+- [x] **Task 4: Unit tests** (AC: #1, #2, #4)
+  - [x] **Classifier (`tests/unit/services/metadata/test_backtestable.py`, `@pytest.mark.unit`):**
+    - `is_backtestable(ResolutionStatus.RESOLVED) is True`; `is_backtestable(ResolutionStatus.VENUE_UNRESOLVED) is False`; `is_backtestable(ResolutionStatus.UNRESOLVED) is False`.
+    - `total_bars` on a `CatalogInstrument` with e.g. `bar_count_daily=2, bar_count_minute=3` (others 0) → `5`; all-zero → `0`.
+    - `NonBacktestableTicker("ZZZ", 10).bars_kept is True`; `NonBacktestableTicker("QQQ", 0).bars_kept is False`; dataclass is frozen (immutability).
+  - [x] **CLI (`tests/unit/cli/commands/test_metadata.py`, `CliRunner`, `@pytest.mark.unit`):** patch `get_sync_session`, `SyncInstrumentMetadataRepository`, and `SyncCatalogInstrumentRepository` (via a `_patch_both_repos` helper). Stub `count_by_status.return_value = {RESOLVED: 3, VENUE_UNRESOLVED: 1}`, `list_by_status.return_value = [_degraded_row("ZZZ")]`, and `cat_repo.get_by_ticker.return_value` = a `CatalogInstrument` with `bar_count_minute=100`.
+    - **Flagged case:** `metadata backtestable` → exit 0, output contains `ZZZ`, `100`, `Non-backtestable (venue unresolved): 1`, `bars retained`, and the venue_overrides hint.
+    - **All-clear:** `list_by_status.return_value = []`, only RESOLVED counts → exit 0, output contains `0 non-backtestable` and the green all-clear.
+    - **Never-attempted surfaced:** counts `{RESOLVED: 2, UNRESOLVED: 3}`, no flagged → exit 0, output does NOT claim `All venue-resolved`, and shows `Not yet attempted (UNRESOLVED): 3` (transparency — Review Finding).
+    - **Empty DB:** `count_by_status.return_value = {}` → exit 0, output contains `No metadata rows yet` (not a green success banner).
+    - **Ticker with no catalog row:** `cat_repo.get_by_ticker.return_value = None` → exit 0, flagged ticker rendered with `0` bars retained (no crash). (AC1 — still flagged/excluded even when it has no bars.)
+    - **DB unconfigured:** `get_sync_session().__enter__` raises `RuntimeError(...)` → exit 0, `result.exception is None`, output contains `Metadata DB not available` (AC4).
+    - **`--catalog` override:** `["backtestable", "--catalog", "custom-cat"]` → asserts `cat_repo.get_by_ticker` called with `"custom-cat"`.
+  - [x] **Render helper (`TestRenderBacktestable`, `capsys`, no CliRunner):** direct `_render_backtestable("firstrate-etf", 3, 0, [NonBacktestableTicker("ZZZ", 100)])` asserts the ticker, bar count, `Non-backtestable (venue unresolved): 1`; the all-clear, never-attempted, and empty cases assert their respective banners.
+
+- [x] **Task 5: Component test — AC3 transition** (AC: #3)
+  - [x] In `tests/component/db/test_instrument_metadata_repository.py` add `test_venue_override_transitions_ticker_to_backtestable` (AC3): seed one `RESOLVED` row + one `VENUE_UNRESOLVED` row (via `_make_metadata`/`upsert`). Assert `list_by_status(RESOLVED)` = the resolved ticker only and the unresolved ticker is `is_backtestable(...) is False`. Then `apply_venue_override(unresolved_ticker, "ARCA", <ts>)`; assert it now appears in `list_by_status(RESOLVED)` and `is_backtestable` of its status is `True` — the transition happens with **no** bar/import operation (pure metadata flip). [Source: tests/component/db/test_instrument_metadata_repository.py (`apply_venue_override` + `list_by_status` precedents from Stories 3.2/3.3)]
+
+- [x] **Task 6: Verify** (AC: all)
+  - [x] `uv run ruff check .` clean — mind the F401/F821 import gate (new `backtestable` module imports; `SyncCatalogInstrumentRepository`, `NonBacktestableTicker`, `total_bars` in the CLI; `total_bars` in the mapper).
+  - [x] `uv run mypy .` — no **new** errors vs the known baseline (`reference_mypy_baseline_debt`: 6 pre-existing in `ui/explorer`, `ui/backtests` + 2 tests). Fully annotate the new function/dataclass/helper.
+  - [x] `make test-unit` green (classifier + mapper orphan guard + CLI/render deltas, no regressions). `make test-component` green for the new mapper + transition tests.
+  - [x] Size limits: files `< 500` lines, functions `< 50`, classes `< 100`, line length `≤ 100`.
+  - [x] Smoke: covered by `CliRunner` tests (help/registration + report output + DB-unconfigured warning); the harness permission mode blocks the live `python -m src.cli.main` subprocess, so the identical command paths are exercised via `CliRunner.invoke`.
+
+### Review Findings
+
+Adversarial review (Blind Hunter · Edge Case Hunter). One High finding reverted a whole task; two Med transparency findings patched; scope findings documented.
+
+- [x] [Review][Revert] **Keep-bars `sync_qualification` fix re-admits guessed-venue tickers to backtests (Edge Case, High).** The implemented "keep the provisional `nautilus_id` when bars are present" change left a `VENUE_UNRESOLVED` ticker with a live `nautilus_id`. `backtest_loader.load_from_catalog` (verified at `backtest_loader.py:136-147`) and the explorer/stats/chart API paths gate backtestability **only** on `nautilus_id`, never on `resolution_status` — so the "excluded" ticker would load bars and run a backtest under its guessed/provisional venue, violating AC1 and ADR-6. **Reverted** the entire Task-2 mapper change (source + unit + component tests); `sync_qualification` is back to Story 3.1 behavior (null the id — the correct exclusion). AC2 still holds (Parquet never deleted; retained bars reported). The "reachable AND excluded" reconciliation is re-deferred to Epic 5 with a consumer-honored flag. Updated `deferred-work.md`.
+- [x] [Review][Patch] **`UNRESOLVED` (never-attempted) rows reported as neither backtestable nor flagged → misleading green "0 non-backtestable" (Edge Case, Med).** The report only counted `RESOLVED` and listed `VENUE_UNRESOLVED`; a store with `UNRESOLVED` rows and no `VENUE_UNRESOLVED` printed the green "✓ All venue-resolved" banner while a third non-backtestable bucket was silently omitted. Fixed: the command now reads the never-attempted count and `_render_backtestable` surfaces `Not yet attempted (UNRESOLVED): N`, withholds the green all-clear unless both buckets are empty, and prints "No metadata rows yet" on an empty store (also addresses the empty-DB green-banner finding). Added render + CLI tests.
+- [x] [Review][Patch/Doc] **Catalog-scope mismatch: global metadata flag set vs single-catalog bar evidence (Blind + Edge Case, Low).** `instrument_metadata` is catalog-global (keyed by ticker) but bar evidence is read from one `catalog_name`; a flagged ticker whose bars live in another catalog reads "0 bars retained". Clarified by labelling the bars column `Bars retained ({catalog})` so the operator sees the scope; the multi-catalog sweep remains Open Question #2 (documented default).
+- [x] [Review][Ack] **N+1 `get_by_ticker` per flagged ticker (Blind, Low).** O(flagged) lookups. Acceptable — the `VENUE_UNRESOLVED` set is the small, shrinking worklist (the whole point of Epic 3 is to drive it to 0); a batched fetch is a premature optimization for a report. No change.
+- [x] [Review][Defer] **Re-resolving to a *different* venue than the bars were written under orphans the partition (Edge Case, High-conditional).** A cross-run ticker's bars sit under partition `SPY.<provisional>`; resolving to a different venue builds a `bar_type` under `SPY.<new>` → loader finds no bars. Pre-existing partition-path coupling, same root as the reverted item; the AC3 "no re-import" promise holds only when the resolved venue matches the write-time venue. Re-deferred to Epic 5 (backtest integration) alongside the consumer-honored flag. Recorded in `deferred-work.md`.
+
+## Dev Notes
+
+### The core idea (why this story exists)
+Epic 3 gates ETF-universe completion on 100% venue coverage. Story 3.1 qualified resolved tickers; 3.2 gave the worklist; 3.3 let the operator fix venues; 3.4 counts + gates. Story 3.5 is the **enforcement of the exclude/flag/keep-bars contract**: an unresolved-venue ticker is kept **out** of the backtestable universe and flagged, but its bars are **never** dropped or orphaned — and the moment its venue is resolved it flows back in with no re-import. This is the "no unresolved ticker silently enters a backtest, no data lost" guarantee. [Source: epics.md Story 3.5; epics.md:142 "Unresolved tickers keep their bars but are flagged non-backtestable"]
+
+### Design decision — the backtestable universe is a live derivation over `resolution_status`
+Backtestable ⟺ `resolution_status == RESOLVED`. The universe is **derived** from the current metadata verdict, not stored as a boolean and not read off `catalog_instruments.nautilus_id`. Three payoffs:
+- **AC1 robustness** — the enumeration/report keys on the venue verdict, and the real backtest path independently excludes the ticker because Story 3.1 nulls its `nautilus_id` (which `backtest_loader` gates on). Both agree: a `VENUE_UNRESOLVED` ticker is out.
+- **AC3 for free** — the Story 3.3 override flips the row to `RESOLVED`; the next enumeration derives it as backtestable. No re-qualify pass, no re-import, no second write path to keep in sync.
+- **No migration** — `resolution_status` + its index (`ix_instrument_metadata_resolution_status`) already exist; `list_by_status(RESOLVED)` **is** the enumeration and `list_by_status(VENUE_UNRESOLVED)` **is** the flagged set. [Source: src/db/models/instrument_metadata.py:71; src/db/repositories/instrument_metadata_repository_sync.py:87-135]
+
+### AC2 (keep bars) — nulling the identity is correct; keeping it was tried & reverted
+Story 3.1 nulls `nautilus_id` on a `VENUE_UNRESOLVED` ticker. The 3.1 deferred-work note asked 3.5 to instead **keep** the provisional id when the row still holds bars, so those bars stay reachable (avoid the cross-run "orphan"). That was implemented, then **reverted during code review**: `backtest_loader.load_from_catalog` (and `api/rest/explorer.py`, `api/stats_service.py`, `api/chart_bars.py`) decide backtestability **solely from `catalog_instruments.nautilus_id`** — they never read `resolution_status`. So a kept provisional id lets an unresolved-venue ticker **run a backtest under a guessed venue** (AC1 + ADR-6 violation), strictly worse than the benign "unreachable-by-id" orphan. Final decision: leave `sync_qualification` at its 3.1 behavior. AC2 is satisfied because the Parquet is never deleted and `catalog_instruments.bar_count_*` is untouched — `metadata backtestable` reports the retained bars — the ticker is just correctly unreachable-by-id (i.e. excluded) until its venue resolves. The real "reachable AND excluded" fix needs a consumer-honored non-backtestable signal (loader/explorer/stats/chart) — Epic 5 scope. [Source: deferred-work.md updated 2026-07-13; src/services/firstrate/backtest_loader.py:136-147]
+
+### The seam (data + control flow)
+```
+instrument_metadata.resolution_status            catalog_instruments (bars + identity)
+        │  list_by_status(RESOLVED)          ← backtestable universe (AC1)
+        │  list_by_status(VENUE_UNRESOLVED)  ← flagged non-backtestable set
+        │                                         │  get_by_ticker → total_bars (evidence bars kept, AC2)
+        ▼                                         ▼
+  metadata backtestable [--catalog]  (CLI, this story)  → Rich table + summary (report-only, exit 0)
+
+  sync_qualification (import path, unchanged from 3.1): VENUE_UNRESOLVED ⇒ nautilus_id NULL (exclusion the loader honors)
+  apply_venue_override (Story 3.3): VENUE_UNRESOLVED → RESOLVED ⇒ next enumeration = backtestable (AC3, no re-import)
+```
+Read-only over the local cache. No network, no provider call, no write. [Source: architecture.md two-table boundary; backtest_loader.py:136-147]
+
+### Scope boundaries (do NOT do here)
+- **No new DB column / migration / stored `backtestable` flag** — derivation over the existing `resolution_status` + index. Do not add a `non_backtestable` column to `catalog_instruments`.
+- **No venue inference/guessing** — a `VENUE_UNRESOLVED` ticker stays excluded; never fabricate a venue to admit it (ADR-6).
+- **No parquet deletion / no re-import** — this story keeps bars; it never drops a partition and never re-imports on transition.
+- **No override load/merge** — that is Story 3.3 (`apply-overrides`, done). This story reads the post-merge state and proves the transition.
+- **No async/web/explorer surface** — CLI sync path only. The explorer's ETF non-backtestable rendering is Epic 4 (4.4 venue-state distinct from N/A); do not touch UI here.
+- **No changes to the FMP provider, venue map, resolution service, coverage gate (3.4), or the qualified-id math (3.1's `qualified_instrument_id`).** This story adds the classifier, the report, and the orphan-safety branch only.
+
+### Design decision — classifier in `services/metadata`, report in the CLI
+`is_backtestable` / `total_bars` / `NonBacktestableTicker` (pure, no I/O) live in `src/services/metadata/backtestable.py` beside `coverage_report.py`, unit-testable without Click/DB. The CLI owns only session wiring + rendering. Matches the 3.2/3.4 precedent (pure logic → unit tier; CLI thin). [Source: CLAUDE.md Decision Heuristics; src/services/metadata/coverage_report.py; src/services/metadata/unresolved_report.py]
+
+### Previous-story intelligence
+- **Story 3.1 (done)** built `sync_qualification` (nulls the id when unresolved) and deferred a keep-bars reconciliation to this story; that was attempted (Task 2) and **reverted** — nulling is the correct exclusion the loader honors, so the reconciliation is re-deferred to Epic 5. [Source: deferred-work.md updated 2026-07-13; Review Findings]
+- **Story 3.3 (done)** `apply_venue_override` flips a row to `RESOLVED` (venue set) idempotently and touches only `instrument_metadata` — so AC3's transition needs no code beyond re-enumerating. [Source: src/db/repositories/instrument_metadata_repository_sync.py:137-171]
+- **Story 3.4 (done)** added `count_by_status` (indexed grouped count) — reused here for the backtestable (`RESOLVED`) count — and the `metadata` group's graceful-degradation idiom (`(RuntimeError, DatabaseConnectionError, SQLAlchemyError)` → yellow warning). [Source: src/db/repositories/instrument_metadata_repository_sync.py:113-135; src/cli/commands/metadata.py:140-149]
+
+### Testing standards
+- **Unit tier** for the pure classifier, the mapper orphan guard (MagicMock repo), the CLI (`CliRunner`, repos patched), and `_render_backtestable` (`capsys`). **Component tier** for the real-repo orphan round-trip and the metadata transition (in-memory SQLite fixtures). No integration/e2e — no engine, no C extensions. [Source: CLAUDE.md Decision Heuristics; ntrader-testing skill]
+- TDD non-negotiable — Red first for `is_backtestable`/`total_bars`, the `sync_qualification` keep-bars branch, and the CLI command. [Source: development-principles.md]
+
+### Project Structure Notes
+- **New:** `src/services/metadata/backtestable.py` (`is_backtestable`, `total_bars`, `NonBacktestableTicker`).
+- **Modified:** `src/services/firstrate/instrument_mapper.py` (`sync_qualification` keep-bars branch + `_has_bars` + `total_bars` import), `src/cli/commands/metadata.py` (`backtestable` subcommand + `_render_backtestable` + `SyncCatalogInstrumentRepository`/`NonBacktestableTicker`/`total_bars` imports).
+- **New tests:** `tests/unit/services/metadata/test_backtestable.py`.
+- **Modified tests:** `tests/unit/services/firstrate/test_instrument_mapper.py` (orphan guard), `tests/unit/cli/commands/test_metadata.py` (`backtestable` CLI + render), `tests/component/services/firstrate/test_instrument_mapper.py` (keep-bars round-trip), `tests/component/db/test_instrument_metadata_repository.py` (transition).
+
+### References
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-3.5] — story statement + 3 acceptance criteria; FR25
+- [Source: _bmad-output/planning-artifacts/epics.md:142] — "Unresolved tickers keep their bars but are flagged non-backtestable (excluded from qualification)"
+- [Source: _bmad-output/implementation-artifacts/deferred-work.md:5-16] — the Story-3.1-deferred orphan this story closes ("must not null an identity whose partition still holds bars")
+- [Source: src/services/firstrate/instrument_mapper.py:141-182] — `sync_qualification` (the null-vs-keep decision to amend)
+- [Source: src/db/repositories/instrument_metadata_repository_sync.py:87-171] — `list_by_status` / `count_by_status` / `apply_venue_override` (enumeration + transition)
+- [Source: src/db/models/catalog_instrument.py:92-106] — the five `bar_count_*` fields (`total_bars`)
+- [Source: src/cli/commands/metadata.py:43-153] — `metadata` group + `unresolved`/`coverage` idioms to mirror
+- [Source: src/services/metadata/coverage_report.py] — frozen-dataclass / pure-service precedent
+- [Source: src/config.py:153-156] — `firstrate_catalog_name` default (`--catalog` fallback)
+
+### Open questions (non-blocking — proceed with the documented default)
+1. **Backtestable definition.** Default: backtestable ⟺ `resolution_status == RESOLVED` (venue known), independent of whether bars exist. A `RESOLVED` ticker with zero bars is counted backtestable (it has a venue; the "has data" refinement is an Epic-5 loader concern). Flag if the team wants the universe to additionally require `total_bars > 0`.
+2. **`--catalog` scope.** Default: bar evidence is looked up in the single configured ETF catalog (`firstrate_catalog_name`), overridable via `--catalog`. `instrument_metadata` is catalog-global (keyed by ticker), so the flag set is catalog-independent; only the *bars-retained* evidence is catalog-scoped. Flag if a multi-catalog sweep is wanted.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8
+
+### Debug Log References
+
+- `uv run pytest tests/unit/services/metadata/test_backtestable.py tests/unit/services/firstrate/test_instrument_mapper.py tests/unit/cli/commands/test_metadata.py tests/component/services/firstrate/test_instrument_mapper.py tests/component/db/test_instrument_metadata_repository.py` — 95 pass (classifier + CLI/render + AC3 transition; mapper unchanged after revert).
+- `uv run pytest tests/unit tests/component` — post-revert full run (see Change Log).
+- `uv run ruff check .` — All checks passed. `uv run mypy .` — Success: no issues found.
+
+### Completion Notes List
+
+- **AC1** — `is_backtestable(status)` (pure) keys the backtestable universe strictly on `resolution_status == RESOLVED`; `VENUE_UNRESOLVED` tickers are excluded and flagged. `metadata backtestable` reports the RESOLVED count (via the indexed `count_by_status`) and lists the flagged `VENUE_UNRESOLVED` set (via `list_by_status`). The real backtest path also already excludes them: `backtest_loader` gates on `nautilus_id`, which Story 3.1 nulls for `VENUE_UNRESOLVED`.
+- **AC2** — bars are never dropped: this story only reads; the Parquet and `catalog_instruments.bar_count_*` are untouched, and the CLI surfaces `bars_retained` per flagged ticker as evidence. A ticker with no catalog row reports 0 bars (still flagged). Note: the identity-nulling is *intentionally kept* (see Review Findings) — the ticker is unreachable-by-id (correctly excluded), not dropped.
+- **AC3** — a Story 3.3 override flip (`VENUE_UNRESOLVED → RESOLVED`) transitions a ticker into the enumerated backtestable universe with no re-import; the component test proves it over the real sync repo (metadata-level flip, no bar op).
+- **AC4** — DB unset/unreachable → single yellow `Metadata DB not available` warning, no traceback (mirrors `coverage`/`unresolved`); report-only, always exit 0.
+- **Design** — classifier/`total_bars`/`NonBacktestableTicker` are pure (`src/services/metadata/backtestable.py`, beside `coverage_report.py`); the CLI owns only session wiring + rendering. No new columns/migrations/settings, no venue guessing, no parquet deletion, no async/web/explorer surface, no changes to the provider/venue-map/resolution service/gate. **The planned `sync_qualification` keep-bars change was reverted during review** (it re-admitted guessed-venue tickers to backtests) — the mapper is unchanged from Story 3.1.
+
+### Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-13 | Story 3.5 drafted (SM). Status → ready-for-dev. |
+| 2026-07-13 | Implemented pure backtestable classifier (`is_backtestable`/`total_bars`/`NonBacktestableTicker`), a `sync_qualification` keep-bars fix, `metadata backtestable [--catalog]` CLI + `_render_backtestable`; unit + component tests (TDD). Status → review. |
+| 2026-07-13 | Code review (Blind Hunter · Edge Case Hunter). **Reverted** the `sync_qualification` keep-bars change (High: kept id re-admits guessed-venue tickers to backtests — `backtest_loader` gates on `nautilus_id`, not `resolution_status`). Patched report transparency (surface UNRESOLVED never-attempted count; empty-DB note; catalog-scoped bars column). Re-deferred the reachable-AND-excluded fix to Epic 5. Gates green. Status → done. |
+
+### File List
+
+- `src/services/metadata/backtestable.py` (new — pure `is_backtestable` / `total_bars` / `NonBacktestableTicker`)
+- `src/cli/commands/metadata.py` (modified — `backtestable` subcommand + `_collect_non_backtestable` + `_render_backtestable` + imports)
+- `tests/unit/services/metadata/test_backtestable.py` (new — classifier/aggregate)
+- `tests/unit/cli/commands/test_metadata.py` (modified — `backtestable` CLI + render + registration)
+- `tests/component/db/test_instrument_metadata_repository.py` (modified — AC3 transition)
+- `_bmad-output/implementation-artifacts/deferred-work.md` (modified — recorded the reverted keep-bars approach + Epic-5 re-scope)
+- *(reverted, unchanged from Story 3.1: `src/services/firstrate/instrument_mapper.py` + its unit/component tests)*

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -2,6 +2,19 @@
 
 Real, non-blocking findings deferred from code reviews. Each entry notes its source and why it was deferred.
 
+## Deferred from: code review of story 3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue (2026-07-13)
+
+- **Cross-run orphan: existing bars + newly-`VENUE_UNRESOLVED` venue nulls `nautilus_id`**
+  [src/services/firstrate/instrument_mapper.py:sync_qualification]. When a ticker with bars imported under a
+  provisional/CSV venue on a prior run (no-resolver, fault-fallback, or stocks path) later resolves
+  `VENUE_UNRESOLVED`, `sync_qualification` writes `nautilus_id = None` / `exchange = None` while the bars remain on
+  disk — leaving a `catalog_instruments` row with `bar_count > 0` but a NULL identity, so the bars are unreachable
+  by the backtest loader / explorer. Nulling the provisional id is *required* by Story 3.1 AC3 for the fresh case
+  (no bars); the reconciliation for already-imported unresolved tickers (keep the bars, flag non-backtestable,
+  don't orphan) is the explicit deliverable of **Story 3.5 — Exclude & Flag Non-Backtestable Tickers**. Story 3.5
+  must not null an identity whose partition still holds bars. (Cache-first resolution means a once-`RESOLVED`
+  ticker stays resolved, so this only bites the narrow mixed-path cross-run sequence.)
+
 ## Deferred from: code review of story 2-7-import-summary-and-progress-reporting (2026-06-29)
 
 - **`ResolutionSummary` has no bucket for a non-throwing `UNRESOLVED` record**

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -9,11 +9,22 @@ Real, non-blocking findings deferred from code reviews. Each entry notes its sou
   provisional/CSV venue on a prior run (no-resolver, fault-fallback, or stocks path) later resolves
   `VENUE_UNRESOLVED`, `sync_qualification` writes `nautilus_id = None` / `exchange = None` while the bars remain on
   disk — leaving a `catalog_instruments` row with `bar_count > 0` but a NULL identity, so the bars are unreachable
-  by the backtest loader / explorer. Nulling the provisional id is *required* by Story 3.1 AC3 for the fresh case
-  (no bars); the reconciliation for already-imported unresolved tickers (keep the bars, flag non-backtestable,
-  don't orphan) is the explicit deliverable of **Story 3.5 — Exclude & Flag Non-Backtestable Tickers**. Story 3.5
-  must not null an identity whose partition still holds bars. (Cache-first resolution means a once-`RESOLVED`
-  ticker stays resolved, so this only bites the narrow mixed-path cross-run sequence.)
+  by the backtest loader / explorer. (Cache-first resolution means a once-`RESOLVED` ticker stays resolved, so
+  this only bites the narrow mixed-path cross-run sequence.)
+
+  **UPDATE (Story 3.5, 2026-07-13): the naive "keep the identity" fix was tried and REJECTED.** Keeping the
+  provisional `nautilus_id` so bars stay reachable was implemented in Story 3.5, then reverted during its code
+  review: `backtest_loader.load_from_catalog` (and `api/rest/explorer.py`, `api/stats_service.py`,
+  `api/chart_bars.py`) gate backtestability **solely on `catalog_instruments.nautilus_id`** — they never consult
+  `resolution_status`. So keeping a provisional id lets an unresolved-venue ticker *run a backtest under a guessed
+  venue*, directly violating Story 3.5 AC1 ("never silently enter a backtest") and ADR-6 (no guessed venues) —
+  strictly worse than the orphan it fixes. Nulling the id is the correct exclusion mechanism the real backtest
+  path honors, and the Parquet is never deleted (Story 3.5 AC2 is satisfied: bars physically present, just
+  unreachable-by-id until the venue resolves). **The true fix — keep bars reachable AND excluded — needs a
+  consumer-honored non-backtestable signal (e.g. a `catalog_instruments.backtestable` flag or a
+  `resolution_status` join threaded through `backtest_loader`/explorer/stats/chart), which is a backtest-
+  integration change and belongs in Epic 5, not Story 3.5.** Also open: re-resolving to a *different* venue than
+  the bars were written under orphans the partition regardless (bar_type path mismatch) — same Epic-5 scope.
 
 ## Deferred from: code review of story 2-7-import-summary-and-progress-reporting (2026-06-29)
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-06-17
-last_updated: "2026-06-29"  # Story 2.7 (import summary & progress reporting) done
+last_updated: "2026-07-13"  # Epic 3: Story 3.1 (venue-qualified InstrumentId) done
 project: Trading-ntrader
 project_key: NOKEY
 tracking_system: file-system
@@ -71,8 +71,8 @@ development_status:
   epic-2-retrospective: optional
 
   # Epic 3: Venue Resolution & Completeness Gate
-  epic-3: backlog
-  3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue: backlog
+  epic-3: in-progress
+  3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue: done
   3-2-unresolved-venue-report: backlog
   3-3-venue-overrides-csv-merge-with-precedence: backlog
   3-4-venue-coverage-report-and-completeness-gate: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-06-17
-last_updated: "2026-07-13"  # Epic 3: Story 3.4 (venue coverage report + completeness gate) done
+last_updated: "2026-07-13"  # Epic 3 DONE: Story 3.5 (exclude & flag non-backtestable tickers) done → all 5 stories complete
 project: Trading-ntrader
 project_key: NOKEY
 tracking_system: file-system
@@ -71,12 +71,12 @@ development_status:
   epic-2-retrospective: optional
 
   # Epic 3: Venue Resolution & Completeness Gate
-  epic-3: in-progress
+  epic-3: done
   3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue: done
   3-2-unresolved-venue-report: done
   3-3-venue-overrides-csv-merge-with-precedence: done
   3-4-venue-coverage-report-and-completeness-gate: done
-  3-5-exclude-and-flag-non-backtestable-tickers: backlog
+  3-5-exclude-and-flag-non-backtestable-tickers: done
   epic-3-retrospective: optional
 
   # Epic 4: Data Explorer — ETF Support

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-06-17
-last_updated: "2026-07-13"  # Epic 3: Story 3.1 (venue-qualified InstrumentId) done
+last_updated: "2026-07-13"  # Epic 3: Story 3.2 (unresolved-venue report) done
 project: Trading-ntrader
 project_key: NOKEY
 tracking_system: file-system
@@ -73,7 +73,7 @@ development_status:
   # Epic 3: Venue Resolution & Completeness Gate
   epic-3: in-progress
   3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue: done
-  3-2-unresolved-venue-report: backlog
+  3-2-unresolved-venue-report: done
   3-3-venue-overrides-csv-merge-with-precedence: backlog
   3-4-venue-coverage-report-and-completeness-gate: backlog
   3-5-exclude-and-flag-non-backtestable-tickers: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-06-17
-last_updated: "2026-07-13"  # Epic 3: Story 3.2 (unresolved-venue report) done
+last_updated: "2026-07-13"  # Epic 3: Story 3.3 (venue_overrides.csv merge with precedence) done
 project: Trading-ntrader
 project_key: NOKEY
 tracking_system: file-system
@@ -74,7 +74,7 @@ development_status:
   epic-3: in-progress
   3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue: done
   3-2-unresolved-venue-report: done
-  3-3-venue-overrides-csv-merge-with-precedence: backlog
+  3-3-venue-overrides-csv-merge-with-precedence: done
   3-4-venue-coverage-report-and-completeness-gate: backlog
   3-5-exclude-and-flag-non-backtestable-tickers: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-06-17
-last_updated: "2026-07-13"  # Epic 3: Story 3.3 (venue_overrides.csv merge with precedence) done
+last_updated: "2026-07-13"  # Epic 3: Story 3.4 (venue coverage report + completeness gate) done
 project: Trading-ntrader
 project_key: NOKEY
 tracking_system: file-system
@@ -75,7 +75,7 @@ development_status:
   3-1-ticker-nautilus-qualified-instrumentid-via-resolved-venue: done
   3-2-unresolved-venue-report: done
   3-3-venue-overrides-csv-merge-with-precedence: done
-  3-4-venue-coverage-report-and-completeness-gate: backlog
+  3-4-venue-coverage-report-and-completeness-gate: done
   3-5-exclude-and-flag-non-backtestable-tickers: backlog
   epic-3-retrospective: optional
 

--- a/src/cli/commands/import_data.py
+++ b/src/cli/commands/import_data.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from src.api.models.explorer import ExplorerTimeframe
 
 if TYPE_CHECKING:
-    from src.config import FMPSettings
+    from src.config import FMPSettings, Settings
     from src.services.metadata.instrument_metadata_service import (
         InstrumentMetadataService,
     )
@@ -153,6 +153,56 @@ def _build_metadata_resolver(
     provider = FMPMetadataProvider(FMPClient(fmp_settings))
     repository = SyncInstrumentMetadataRepository(session)
     return InstrumentMetadataService(provider=provider, repository=repository)
+
+
+def _apply_venue_overrides(session: Session, settings: "Settings") -> None:
+    """Merge venue_overrides.csv into the metadata store during import (Story 3.3).
+
+    Thin orchestration helper: load the CSV (path via config), and if it carries
+    any corrections, merge them with precedence into ``instrument_metadata`` on
+    the open session (committed by the caller). A header-only/absent file is a
+    silent no-op; a malformed header degrades to a single warning without
+    aborting the in-flight import (bars already imported are preserved).
+
+    Args:
+        session: Open sync DB session (shares the import transaction).
+        settings: Application settings (provides the override path).
+    """
+    from datetime import datetime, timezone
+
+    from rich.markup import escape
+
+    from src.db.repositories.instrument_metadata_repository_sync import (
+        SyncInstrumentMetadataRepository,
+    )
+    from src.services.metadata.venue_overrides import (
+        VenueOverrideError,
+        load_venue_overrides,
+        merge_venue_overrides,
+    )
+
+    path = Path(settings.firstrate.firstrate_venue_overrides_path)
+    try:
+        overrides = load_venue_overrides(path)
+    except VenueOverrideError as exc:
+        # exc text embeds the raw header repr (bracketed) / file path — escape so a
+        # Rich metacharacter can't raise MarkupError and abort the in-flight import.
+        console.print(f"[yellow]Venue overrides not applied — {escape(str(exc))}[/yellow]")
+        return
+    if not overrides:
+        return
+    result = merge_venue_overrides(
+        overrides,
+        SyncInstrumentMetadataRepository(session),
+        datetime.now(timezone.utc),
+    )
+    console.print(
+        f"Venue overrides: {result.applied} applied, "
+        f"{result.unchanged} unchanged, {len(result.unmatched)} unmatched"
+    )
+    if result.unmatched:
+        joined = ", ".join(escape(t) for t in result.unmatched)
+        console.print(f"[yellow]Unmatched (no metadata row): {joined}[/yellow]")
 
 
 def _find_profiles_csv(source_path: Path) -> Path | None:
@@ -356,6 +406,12 @@ def _run_import(
                 _print_progress_line(r, tf)
 
             all_results.extend(results)
+
+        # Story 3.3: merge manual venue corrections (venue_overrides.csv) into the
+        # metadata store with precedence — runs in the import-orchestration step
+        # (not FMPClient), after the FMP-resolved rows are written and before the
+        # single commit, so overrides win over absent/ambiguous provider venues.
+        _apply_venue_overrides(session, settings)
 
         # Commit all profile loads and metadata upserts as a single transaction.
         session.commit()

--- a/src/cli/commands/import_reporting.py
+++ b/src/cli/commands/import_reporting.py
@@ -134,7 +134,11 @@ def _print_progress_line(result: ImportResult, timeframe: str) -> None:
         timeframe: Timeframe spec used for this import.
     """
     if result.status == "skipped":
-        click.echo(f"{result.ticker} — {timeframe} — skipped (already complete) ⟳")
+        # Idempotent skips carry no error → "already complete". A venue-
+        # unresolved skip (Story 3.1) carries a reason in `error` so the line is
+        # honest rather than falsely claiming the ticker was already imported.
+        reason = result.error or "already complete"
+        click.echo(f"{result.ticker} — {timeframe} — skipped ({reason}) ⟳")
     elif result.status == "success":
         # Append a ⚠ when the import carried non-blocking OHLC-sanity flags
         # (Story 2.5 AC4) so a long run is scannable for verification issues.

--- a/src/cli/commands/metadata.py
+++ b/src/cli/commands/metadata.py
@@ -1,0 +1,67 @@
+"""CLI commands for instrument metadata inspection (Story 3.2+).
+
+Read-only reports over the local ``instrument_metadata`` cache table. No network
+or provider call — the resolved metadata is produced by the Epic-1 resolution
+service and the Story 3.1 import qualification.
+"""
+
+import click
+from rich.console import Console
+from rich.markup import escape
+from rich.table import Table
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.db.exceptions import DatabaseConnectionError
+from src.db.models.instrument_metadata import InstrumentMetadata
+from src.db.repositories.instrument_metadata_repository_sync import (
+    SyncInstrumentMetadataRepository,
+)
+from src.db.session_sync import get_sync_session
+from src.models.instrument_metadata import ResolutionStatus
+from src.services.metadata.unresolved_report import unresolved_reason
+
+console = Console()
+
+
+@click.group()
+def metadata() -> None:
+    """Instrument metadata inspection commands."""
+
+
+@metadata.command("unresolved")
+def unresolved() -> None:
+    """List every ticker whose venue is unresolved (VENUE_UNRESOLVED).
+
+    A worklist for driving the ETF universe to 100% venue coverage — each row
+    carries a derived reason and is the basis for filling in venue_overrides.csv
+    (Story 3.3).
+    """
+    try:
+        with get_sync_session() as session:
+            rows = SyncInstrumentMetadataRepository(session).list_by_status(
+                ResolutionStatus.VENUE_UNRESOLVED
+            )
+    except (RuntimeError, DatabaseConnectionError, SQLAlchemyError) as exc:
+        # DB unset (RuntimeError), unreachable/missing-table/bad-URL (SQLAlchemyError),
+        # or a translated connection failure — degrade to a warning, never a traceback.
+        console.print(f"[yellow]Metadata DB not available — {escape(str(exc))}[/yellow]")
+        return
+    _render_unresolved(rows)
+
+
+def _render_unresolved(rows: list[InstrumentMetadata]) -> None:
+    """Render the unresolved-venue rows as a Rich table (or an all-clear line)."""
+    if not rows:
+        console.print("[green]✓ All venues resolved — no unresolved-venue tickers.[/green]")
+        return
+    table = Table(title="Unresolved-venue tickers")
+    table.add_column("Ticker", style="cyan")
+    table.add_column("Provider")
+    table.add_column("Reason")
+    for row in rows:
+        # ticker/provider are DB-sourced (String(20)) — escape so a stray Rich
+        # markup metacharacter can't raise MarkupError or mis-render.
+        table.add_row(escape(row.ticker), escape(row.metadata_provider), unresolved_reason(row))
+    console.print(table)
+    console.print(f"{len(rows)} ticker(s) with unresolved venue")
+    console.print("Add the correct venue for each in venue_overrides.csv (Story 3.3) to resolve.")

--- a/src/cli/commands/metadata.py
+++ b/src/cli/commands/metadata.py
@@ -8,6 +8,7 @@ service and the Story 3.1 import qualification.
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 import click
 from rich.console import Console
@@ -18,11 +19,15 @@ from sqlalchemy.exc import SQLAlchemyError
 from src.config import get_settings
 from src.db.exceptions import DatabaseConnectionError
 from src.db.models.instrument_metadata import InstrumentMetadata
+from src.db.repositories.catalog_instrument_repository import (
+    SyncCatalogInstrumentRepository,
+)
 from src.db.repositories.instrument_metadata_repository_sync import (
     SyncInstrumentMetadataRepository,
 )
 from src.db.session_sync import get_sync_session
 from src.models.instrument_metadata import ResolutionStatus
+from src.services.metadata.backtestable import NonBacktestableTicker, total_bars
 from src.services.metadata.coverage_report import VenueCoverage
 from src.services.metadata.unresolved_report import unresolved_reason
 from src.services.metadata.venue_overrides import (
@@ -187,4 +192,93 @@ def _render_coverage(cov: VenueCoverage) -> None:
         console.print(
             f"[red]✗ INCOMPLETE — {cov.venue_unresolved} ticker(s) VENUE_UNRESOLVED "
             f"(gate FAIL)[/red]"
+        )
+
+
+@metadata.command("backtestable")
+@click.option(
+    "--catalog",
+    default=None,
+    help="Catalog to read bar-retention evidence from (default: firstrate_catalog_name).",
+)
+def backtestable(catalog: Optional[str]) -> None:
+    """Enumerate the backtestable universe and flag non-backtestable tickers (Story 3.5).
+
+    Backtestable ⟺ a RESOLVED venue. Tickers with VENUE_UNRESOLVED are excluded
+    and flagged non-backtestable — but their imported bars are retained (excluded
+    ≠ dropped). Resolving a venue (venue_overrides.csv, Story 3.3) transitions a
+    ticker back in with no re-import.
+    """
+    catalog_name = catalog or get_settings().firstrate.firstrate_catalog_name
+    try:
+        with get_sync_session() as session:
+            meta_repo = SyncInstrumentMetadataRepository(session)
+            cat_repo = SyncCatalogInstrumentRepository(session)
+            counts = meta_repo.count_by_status()
+            unresolved_rows = meta_repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED)
+            flagged = _collect_non_backtestable(unresolved_rows, cat_repo, catalog_name)
+    except (RuntimeError, DatabaseConnectionError, SQLAlchemyError) as exc:
+        console.print(f"[yellow]Metadata DB not available — {escape(str(exc))}[/yellow]")
+        return
+    _render_backtestable(
+        catalog_name,
+        counts.get(ResolutionStatus.RESOLVED, 0),
+        counts.get(ResolutionStatus.UNRESOLVED, 0),
+        flagged,
+    )
+
+
+def _collect_non_backtestable(
+    rows: list[InstrumentMetadata],
+    cat_repo: SyncCatalogInstrumentRepository,
+    catalog_name: str,
+) -> list[NonBacktestableTicker]:
+    """Pair each unresolved ticker with the bars still retained for it (0 if no row)."""
+    flagged: list[NonBacktestableTicker] = []
+    for row in rows:
+        inst = cat_repo.get_by_ticker(catalog_name, row.ticker)
+        bars = total_bars(inst) if inst is not None else 0
+        flagged.append(NonBacktestableTicker(row.ticker, bars))
+    return flagged
+
+
+def _render_backtestable(
+    catalog_name: str,
+    backtestable_count: int,
+    never_attempted: int,
+    flagged: list[NonBacktestableTicker],
+) -> None:
+    """Render the backtestable count + the flagged non-backtestable set (no exit logic)."""
+    total = backtestable_count + never_attempted + len(flagged)
+    if total == 0:
+        console.print("[yellow]No metadata rows yet — nothing to enumerate.[/yellow]")
+        return
+    if not flagged and never_attempted == 0:
+        console.print(
+            f"[green]✓ All venue-resolved — backtestable universe = {backtestable_count} "
+            f"ticker(s), 0 non-backtestable.[/green]"
+        )
+        return
+    if flagged:
+        table = Table(title="Non-backtestable tickers (venue unresolved)")
+        table.add_column("Ticker", style="cyan")
+        table.add_column(f"Bars retained ({escape(catalog_name)})", justify="right")
+        for t in flagged:
+            table.add_row(escape(t.ticker), str(t.bars_retained))
+        console.print(table)
+    console.print(
+        f"Backtestable: {backtestable_count} · Non-backtestable (venue unresolved): "
+        f"{len(flagged)} (bars retained, not dropped)"
+    )
+    if never_attempted > 0:
+        # UNRESOLVED = resolution never ran; also non-backtestable, but not the
+        # venue-unresolved flagged set (no override fixes a not-yet-attempted row).
+        console.print(
+            f"[yellow]Not yet attempted (UNRESOLVED): {never_attempted} — resolution has "
+            f"not run on these; they are not backtestable either.[/yellow]"
+        )
+    if flagged:
+        console.print(
+            "Bars are kept on disk — resolve each venue in venue_overrides.csv (Story 3.3) "
+            "to make it backtestable."
         )

--- a/src/cli/commands/metadata.py
+++ b/src/cli/commands/metadata.py
@@ -5,6 +5,7 @@ or provider call — the resolved metadata is produced by the Epic-1 resolution
 service and the Story 3.1 import qualification.
 """
 
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -22,6 +23,7 @@ from src.db.repositories.instrument_metadata_repository_sync import (
 )
 from src.db.session_sync import get_sync_session
 from src.models.instrument_metadata import ResolutionStatus
+from src.services.metadata.coverage_report import VenueCoverage
 from src.services.metadata.unresolved_report import unresolved_reason
 from src.services.metadata.venue_overrides import (
     VenueOverrideError,
@@ -119,3 +121,70 @@ def _render_override_summary(result: VenueOverrideMergeResult) -> None:
     if result.unmatched:
         joined = ", ".join(escape(t) for t in result.unmatched)
         console.print(f"[yellow]Unmatched (no metadata row): {joined}[/yellow]")
+
+
+@metadata.command("coverage")
+@click.option(
+    "--gate/--no-gate",
+    default=False,
+    help="Exit non-zero unless venue coverage is 100% (for CI/automation).",
+)
+def coverage(gate: bool) -> None:
+    """Report venue coverage and the completeness verdict (Story 3.4).
+
+    Answers "is any ticker missing a venue?" from a single indexed grouped
+    count. A VENUE_UNRESOLVED row fails the gate — no venue is ever guessed to
+    make it pass. With --gate the process exits 1 when INCOMPLETE (and 2 when
+    the DB cannot be evaluated, so CI never mistakes "unreachable" for "passed").
+    """
+    try:
+        with get_sync_session() as session:
+            counts = SyncInstrumentMetadataRepository(session).count_by_status()
+    except (RuntimeError, DatabaseConnectionError, SQLAlchemyError) as exc:
+        # DB unset / unreachable / missing-table — degrade to a warning, never a
+        # traceback. Under --gate an unevaluable gate must NOT read as passing.
+        console.print(f"[yellow]Metadata DB not available — {escape(str(exc))}[/yellow]")
+        if gate:
+            sys.exit(2)
+        return
+    cov = VenueCoverage.from_counts(counts)
+    _render_coverage(cov)
+    if gate and not cov.is_complete:
+        sys.exit(1)
+
+
+def _render_coverage(cov: VenueCoverage) -> None:
+    """Render the venue-coverage breakdown + PASS/FAIL verdict (no exit logic)."""
+    table = Table(title="Venue coverage")
+    table.add_column("Status", style="cyan")
+    table.add_column("Count", justify="right")
+    table.add_row("RESOLVED", str(cov.resolved))
+    table.add_row("VENUE_UNRESOLVED", str(cov.venue_unresolved))
+    table.add_row("UNRESOLVED", str(cov.unresolved))
+    console.print(table)
+    console.print(f"Total metadata rows: {cov.total}")
+    # Clamp the *displayed* percent so it can never read 100.0% while the verdict
+    # is FAIL: f"{x:.1f}" rounds 99.95–99.99…% up to "100.0%". is_complete (the
+    # exact float) drives the exit code; this only keeps the printed line honest.
+    pct = cov.coverage_pct
+    if not cov.is_complete and pct >= 99.95:
+        pct = 99.9
+    console.print(f"Venue coverage: {pct:.1f}% ({cov.resolved}/{cov.decided} decided)")
+    console.print(f"Unresolved venues (VENUE_UNRESOLVED): {cov.venue_unresolved}")
+    if cov.unresolved > 0:
+        console.print(f"Not yet attempted (UNRESOLVED): {cov.unresolved}")
+    if cov.total == 0:
+        console.print("[yellow]No metadata rows yet — nothing to gate (vacuous PASS).[/yellow]")
+    elif cov.decided == 0:
+        # Only never-attempted rows — resolution never ran, so 100%/PASS is vacuous.
+        console.print(
+            "[yellow]No venues decided yet — resolution has not run on any row; "
+            "PASS is vacuous.[/yellow]"
+        )
+    if cov.is_complete:
+        console.print("[green]✓ COMPLETE — venue coverage 100% (gate PASS)[/green]")
+    else:
+        console.print(
+            f"[red]✗ INCOMPLETE — {cov.venue_unresolved} ticker(s) VENUE_UNRESOLVED "
+            f"(gate FAIL)[/red]"
+        )

--- a/src/cli/commands/metadata.py
+++ b/src/cli/commands/metadata.py
@@ -5,12 +5,16 @@ or provider call — the resolved metadata is produced by the Epic-1 resolution
 service and the Story 3.1 import qualification.
 """
 
+from datetime import datetime, timezone
+from pathlib import Path
+
 import click
 from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
 from sqlalchemy.exc import SQLAlchemyError
 
+from src.config import get_settings
 from src.db.exceptions import DatabaseConnectionError
 from src.db.models.instrument_metadata import InstrumentMetadata
 from src.db.repositories.instrument_metadata_repository_sync import (
@@ -19,6 +23,12 @@ from src.db.repositories.instrument_metadata_repository_sync import (
 from src.db.session_sync import get_sync_session
 from src.models.instrument_metadata import ResolutionStatus
 from src.services.metadata.unresolved_report import unresolved_reason
+from src.services.metadata.venue_overrides import (
+    VenueOverrideError,
+    VenueOverrideMergeResult,
+    load_venue_overrides,
+    merge_venue_overrides,
+)
 
 console = Console()
 
@@ -65,3 +75,47 @@ def _render_unresolved(rows: list[InstrumentMetadata]) -> None:
     console.print(table)
     console.print(f"{len(rows)} ticker(s) with unresolved venue")
     console.print("Add the correct venue for each in venue_overrides.csv (Story 3.3) to resolve.")
+
+
+@metadata.command("apply-overrides")
+def apply_overrides() -> None:
+    """Merge venue_overrides.csv into the metadata store, with precedence (Story 3.3).
+
+    The metadata-refresh path: fill the CSV from the ``metadata unresolved``
+    worklist, then apply the corrections without re-importing bars. Each override
+    flips a matching row to RESOLVED; re-running is idempotent.
+    """
+    path = Path(get_settings().firstrate.firstrate_venue_overrides_path)
+    try:
+        overrides = load_venue_overrides(path)
+    except VenueOverrideError as exc:
+        console.print(f"[yellow]Venue overrides not applied — {escape(str(exc))}[/yellow]")
+        return
+    if not overrides:
+        console.print(
+            f"[green]✓ No venue overrides to apply ({escape(str(path))} is empty/absent).[/green]"
+        )
+        return
+    try:
+        with get_sync_session() as session:
+            result = merge_venue_overrides(
+                overrides,
+                SyncInstrumentMetadataRepository(session),
+                datetime.now(timezone.utc),
+            )
+            session.commit()
+    except (RuntimeError, DatabaseConnectionError, SQLAlchemyError) as exc:
+        console.print(f"[yellow]Metadata DB not available — {escape(str(exc))}[/yellow]")
+        return
+    _render_override_summary(result)
+
+
+def _render_override_summary(result: VenueOverrideMergeResult) -> None:
+    """Print a one-line venue-override merge summary (+ unmatched tickers, if any)."""
+    console.print(
+        f"Venue overrides: {result.applied} applied, "
+        f"{result.unchanged} unchanged, {len(result.unmatched)} unmatched"
+    )
+    if result.unmatched:
+        joined = ", ".join(escape(t) for t in result.unmatched)
+        console.print(f"[yellow]Unmatched (no metadata row): {joined}[/yellow]")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -7,6 +7,7 @@ from src.cli.commands.backtest import backtest  # noqa: E402
 from src.cli.commands.data import data  # noqa: E402
 from src.cli.commands.history import list_backtest_history  # noqa: E402
 from src.cli.commands.import_data import import_firstrate  # noqa: E402
+from src.cli.commands.metadata import metadata  # noqa: E402
 from src.cli.commands.report import report  # noqa: E402
 from src.cli.commands.run import run_simple  # noqa: E402
 from src.cli.commands.strategy import strategy  # noqa: E402
@@ -40,6 +41,7 @@ cli.add_command(strategy)
 cli.add_command(report)
 cli.add_command(list_backtest_history)
 cli.add_command(import_firstrate, "import")
+cli.add_command(metadata)
 
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -154,6 +154,10 @@ class FirstRateSettings(BaseSettings):
         default="firstrate-etf",
         description="Default catalog name for FirstRate imports",
     )
+    firstrate_venue_overrides_path: str = Field(
+        default="venue_overrides.csv",
+        description="Path to the git-tracked venue overrides CSV (header: ticker,venue)",
+    )
 
     model_config = {
         "env_file": ".env",

--- a/src/db/repositories/instrument_metadata_repository_sync.py
+++ b/src/db/repositories/instrument_metadata_repository_sync.py
@@ -8,6 +8,7 @@ Operates on the SQLAlchemy ORM ``InstrumentMetadata``
 same name. ORM↔domain mapping is the Story 1.5 service's responsibility.
 """
 
+from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import select
@@ -106,5 +107,41 @@ class SyncInstrumentMetadataRepository:
         )
         try:
             return list(self.session.execute(stmt).scalars().all())
+        except OperationalError as e:
+            raise DatabaseConnectionError(f"Database connection failed: {e}") from e
+
+    def apply_venue_override(self, ticker: str, venue: str, resolved_at: datetime) -> str:
+        """Apply a manual venue override to an existing row, with precedence (Story 3.3).
+
+        Sets ``venue`` and forces ``resolution_status = RESOLVED`` (the operator's
+        correction wins over absent/ambiguous provider data). Idempotent: a row
+        already at the override target (``venue`` matches and status ``RESOLVED``)
+        is left untouched — no write, no ``resolved_at`` churn. A ticker with no
+        row is reported ``"unmatched"`` (never fabricated). Descriptive fields are
+        never touched.
+
+        Args:
+            ticker: Ticker to correct (must already exist in the store).
+            venue: Operator-supplied Nautilus venue code.
+            resolved_at: Timestamp stamped on a row this call changes.
+
+        Returns:
+            One of ``"applied"`` (row changed), ``"unchanged"`` (already at
+            target), or ``"unmatched"`` (no such row).
+
+        Raises:
+            DatabaseConnectionError: If the query/flush fails (mirrors ``upsert``).
+        """
+        try:
+            row = self.get_by_ticker(ticker)
+            if row is None:
+                return "unmatched"
+            if row.venue == venue and row.resolution_status == ResolutionStatus.RESOLVED:
+                return "unchanged"
+            row.venue = venue
+            row.resolution_status = ResolutionStatus.RESOLVED
+            row.resolved_at = resolved_at
+            self.session.flush()
+            return "applied"
         except OperationalError as e:
             raise DatabaseConnectionError(f"Database connection failed: {e}") from e

--- a/src/db/repositories/instrument_metadata_repository_sync.py
+++ b/src/db/repositories/instrument_metadata_repository_sync.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 
 from src.db.exceptions import DatabaseConnectionError, DuplicateRecordError
 from src.db.models.instrument_metadata import InstrumentMetadata
+from src.models.instrument_metadata import ResolutionStatus
 
 
 class SyncInstrumentMetadataRepository:
@@ -81,3 +82,29 @@ class SyncInstrumentMetadataRepository:
         stmt = select(InstrumentMetadata).where(InstrumentMetadata.ticker == ticker)
         result = self.session.execute(stmt)
         return result.scalar_one_or_none()
+
+    def list_by_status(self, status: ResolutionStatus) -> list[InstrumentMetadata]:
+        """List all metadata rows with the given resolution status, ordered by ticker.
+
+        Served by the ``ix_instrument_metadata_resolution_status`` index. Used by
+        the Story 3.2 unresolved-venue report (``VENUE_UNRESOLVED``).
+
+        Args:
+            status: The resolution status to filter on.
+
+        Returns:
+            Metadata rows matching ``status``, ordered by ticker ascending.
+
+        Raises:
+            DatabaseConnectionError: If the query fails (e.g. DB unreachable) —
+                mirrors ``upsert`` so CLI callers can degrade gracefully.
+        """
+        stmt = (
+            select(InstrumentMetadata)
+            .where(InstrumentMetadata.resolution_status == status)
+            .order_by(InstrumentMetadata.ticker)
+        )
+        try:
+            return list(self.session.execute(stmt).scalars().all())
+        except OperationalError as e:
+            raise DatabaseConnectionError(f"Database connection failed: {e}") from e

--- a/src/db/repositories/instrument_metadata_repository_sync.py
+++ b/src/db/repositories/instrument_metadata_repository_sync.py
@@ -11,7 +11,7 @@ same name. ORM↔domain mapping is the Story 1.5 service's responsibility.
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session
 
@@ -109,6 +109,30 @@ class SyncInstrumentMetadataRepository:
             return list(self.session.execute(stmt).scalars().all())
         except OperationalError as e:
             raise DatabaseConnectionError(f"Database connection failed: {e}") from e
+
+    def count_by_status(self) -> dict[ResolutionStatus, int]:
+        """Count rows grouped by resolution status (Story 3.4 coverage gate).
+
+        A single ``COUNT(*) GROUP BY resolution_status`` served by the
+        ``ix_instrument_metadata_resolution_status`` index — O(distinct statuses)
+        w.r.t. row count, not a full-table scan or a Python-side count. Statuses
+        with no rows are simply absent from the map (callers use ``.get(s, 0)``).
+
+        Returns:
+            Map of ``ResolutionStatus`` → row count; ``{}`` when the store is empty.
+
+        Raises:
+            DatabaseConnectionError: If the query fails (mirrors ``upsert``) so CLI
+                callers can degrade gracefully.
+        """
+        stmt = select(InstrumentMetadata.resolution_status, func.count()).group_by(
+            InstrumentMetadata.resolution_status
+        )
+        try:
+            rows = self.session.execute(stmt).all()
+        except OperationalError as e:
+            raise DatabaseConnectionError(f"Database connection failed: {e}") from e
+        return {status: count for status, count in rows}
 
     def apply_venue_override(self, ticker: str, venue: str, resolved_at: datetime) -> str:
         """Apply a manual venue override to an existing row, with precedence (Story 3.3).

--- a/src/services/firstrate/import_service.py
+++ b/src/services/firstrate/import_service.py
@@ -27,6 +27,8 @@ from src.services.firstrate.parsers.base import get_parser
 from src.services.firstrate.source_probe import compute_source_last_date
 
 if TYPE_CHECKING:
+    from nautilus_trader.model.identifiers import InstrumentId
+
     from src.models.instrument_metadata import InstrumentMetadata
     from src.services.metadata.instrument_metadata_service import (
         InstrumentMetadataService,
@@ -139,6 +141,14 @@ class ImportService:
         # unresolved) into the end-of-run summary. Keyed by ticker so a ticker
         # spanning multiple timeframe passes is recorded exactly once.
         self._resolved_metadata: dict[str, "InstrumentMetadata"] = {}
+        # Tickers already venue-qualified this run, mapped to their computed
+        # identity (Story 3.1). The resolved venue is stable within a run
+        # (cache-first), so qualification — a catalog_instruments read+write —
+        # runs at most once per ticker even across the 5 ETF timeframe passes,
+        # mirroring the _resolved_tickers dedup. ``None`` records a deliberately
+        # unqualified (VENUE_UNRESOLVED) ticker so later passes re-skip it
+        # without re-nulling the row every pass.
+        self._qualified_ids: dict[str, "InstrumentId | None"] = {}
 
     @property
     def resolved_metadata(self) -> "list[InstrumentMetadata]":
@@ -294,8 +304,41 @@ class ImportService:
                     duration=time.perf_counter() - start,
                 )
 
-            # 1. Resolve instrument ID
-            instrument_id = self._instrument_mapper.resolve_instrument_id(ticker, catalog_name)
+            # 1a. Resolve instrument metadata (Story 2.4 AC4). Moved ahead of
+            #     identity resolution (Story 3.1): the qualified venue must be
+            #     known before parsing, because bars are stamped with the
+            #     instrument id and written under {INSTRUMENT_ID}/{BAR_TYPE}/ — a
+            #     later venue change would orphan them. Cache-first, deduped, and
+            #     fault-isolated inside the helper (a metadata hiccup never fails
+            #     an otherwise-good bar import).
+            self._resolve_metadata(ticker)
+
+            # 1b. Qualify (Story 3.1): source the venue from the resolved
+            #     instrument_metadata and sync catalog_instruments.nautilus_id
+            #     (ADR-3). A VENUE_UNRESOLVED ticker returns None — left
+            #     unqualified, no nautilus_id fabricated (AC3). Its exclude/flag/
+            #     keep-bars handling is Story 3.5; here it is skipped this run.
+            instrument_id = self._qualify_ticker(ticker, catalog_name)
+            if instrument_id is None:
+                logger.info(
+                    "ticker_unqualified",
+                    ticker=ticker,
+                    catalog=catalog_name,
+                    timeframe=timeframe,
+                    reason="venue unresolved — deferred to Story 3.5",
+                )
+                return ImportResult(
+                    ticker=ticker,
+                    status="skipped",
+                    row_count=0,
+                    outcome="skipped",
+                    # A reason distinguishes this deliberate venue-unresolved skip
+                    # from an idempotent "already complete" skip in the per-ticker
+                    # progress line (error is not surfaced as a failure — the
+                    # summary/exit-code key on status, which stays "skipped").
+                    error="venue unresolved — deferred to Story 3.5",
+                    duration=time.perf_counter() - start,
+                )
 
             # 2. Build BarType
             bar_type = BarType.from_str(f"{instrument_id}-{timeframe}-EXTERNAL")
@@ -340,16 +383,6 @@ class ImportService:
                     invalid_rows=invalid_rows,
                     sample=ohlc_warnings[:3],
                 )
-
-            # 3b. Resolve instrument metadata (Story 2.4 AC4). Cache-first via
-            #     the Epic-1 service, which self-upserts into instrument_metadata
-            #     and skips the provider when the ticker is already RESOLVED.
-            #     Runs once per parsed ticker per run — deduped inside the helper
-            #     so the multi-timeframe ETF default does not re-resolve, and the
-            #     "skipped" short-circuit above means an already-complete re-run
-            #     resolves nothing. Faults are isolated inside the helper so a
-            #     metadata hiccup never fails an otherwise-good bar import.
-            self._resolve_metadata(ticker)
 
             # 4. Write to catalog. Delete any existing bars for this exact
             #    bar_type first so a re-import (or an orphan-heal where the
@@ -714,6 +747,43 @@ class ImportService:
             and a.close == b.close
             and a.volume == b.volume
         )
+
+    def _qualify_ticker(self, ticker: str, catalog_name: str) -> "InstrumentId | None":
+        """Resolve a ticker's Nautilus identity, venue-qualified from metadata (Story 3.1).
+
+        When the Epic-1 resolver ran and captured domain metadata for this ticker, the
+        authoritative resolved ``venue`` drives the qualification: :meth:`InstrumentMapper.
+        sync_qualification` writes ``catalog_instruments.nautilus_id``/``exchange`` (ADR-3)
+        and returns the qualified ``InstrumentId`` — or ``None`` when the venue is
+        ``VENUE_UNRESOLVED`` (``venue is None``), leaving the ticker unqualified (AC3).
+
+        When no resolver is injected (the Phase-1 stocks path / FMP unconfigured) or a
+        provider fault left nothing captured, this falls back to the existing DB identity
+        lookup (:meth:`InstrumentMapper.resolve_instrument_id`) — unchanged behavior (AC4).
+
+        Args:
+            ticker: Trading symbol.
+            catalog_name: Catalog scoping the identity row.
+
+        Returns:
+            The (venue-qualified) ``InstrumentId``, or ``None`` when the venue is unresolved.
+        """
+        metadata = self._resolved_metadata.get(ticker)
+        if self._metadata_resolver is None or metadata is None:
+            return self._instrument_mapper.resolve_instrument_id(ticker, catalog_name)
+        # Qualify at most once per ticker per run (see _qualified_ids).
+        if ticker in self._qualified_ids:
+            return self._qualified_ids[ticker]
+        qualified = self._instrument_mapper.sync_qualification(ticker, catalog_name, metadata.venue)
+        if qualified is None and metadata.venue:
+            # The venue WAS resolved, yet the sync found no catalog_instruments
+            # row — the ticker is absent from company_profiles, not venue-
+            # unresolved. Do not mislabel it as unqualified/deferred: fall back
+            # to resolve_instrument_id so the missing profile fails loudly
+            # (InstrumentMappingError), exactly as on the no-resolver path.
+            return self._instrument_mapper.resolve_instrument_id(ticker, catalog_name)
+        self._qualified_ids[ticker] = qualified
+        return qualified
 
     def _resolve_metadata(self, ticker: str) -> None:
         """Resolve a parsed ticker's instrument metadata cache-first (Story 2.4).

--- a/src/services/firstrate/instrument_mapper.py
+++ b/src/services/firstrate/instrument_mapper.py
@@ -117,6 +117,70 @@ class InstrumentMapper:
         )
         return count
 
+    @staticmethod
+    def qualified_instrument_id(ticker: str, venue: Optional[str]) -> Optional[InstrumentId]:
+        """Compute a Nautilus-qualified ``InstrumentId`` from a resolved venue (Story 3.1).
+
+        Pure: the venue is the authoritative code resolved by ``InstrumentMetadataService``
+        (Epic 1) — never a guessed/CSV value. A falsy venue (``None`` or blank, i.e.
+        ``VENUE_UNRESOLVED``) yields ``None`` so no identity is fabricated (AC3). ``venue``
+        is already guaranteed a real code or ``None`` by the domain model's
+        ``venue_never_na_sentinel`` validator, so the ``NA_SENTINEL`` is not re-checked here.
+
+        Args:
+            ticker: Trading symbol (e.g. "SPY").
+            venue: Resolved Nautilus venue code (e.g. "ARCA"), or ``None``/blank.
+
+        Returns:
+            ``InstrumentId`` (e.g. ``SPY.ARCA``), or ``None`` when the venue is unresolved.
+        """
+        if not venue:
+            return None
+        return InstrumentId.from_str(f"{ticker}.{venue}")
+
+    def sync_qualification(
+        self, ticker: str, catalog_name: str, venue: Optional[str]
+    ) -> Optional[InstrumentId]:
+        """Sync the resolved venue onto ``catalog_instruments`` (ADR-3 qualification sync).
+
+        The import pipeline (single writer) calls this after resolving a ticker's metadata:
+        the authoritative resolved ``venue`` overwrites the provisional CSV exchange on the
+        ``catalog_instruments`` identity row and recomputes ``nautilus_id``. ``instrument_metadata``
+        stays the source of truth for resolved metadata; ``catalog_instruments`` for bar
+        counts/date ranges. A ``VENUE_UNRESOLVED`` ticker (``venue is None``) leaves
+        ``nautilus_id`` ``None`` — unqualified, not fabricated (AC3; excludes/flag are Story 3.5).
+
+        Args:
+            ticker: Trading symbol.
+            catalog_name: Catalog scoping the identity row.
+            venue: Resolved Nautilus venue code, or ``None`` when unresolved.
+
+        Returns:
+            The qualified ``InstrumentId``, or ``None`` when the venue is unresolved or no
+            ``catalog_instruments`` row exists (profiles not loaded).
+        """
+        instrument = self._repo.get_by_ticker(catalog_name, ticker)
+        if instrument is None:
+            logger.warning(
+                "qualification_sync_skipped",
+                ticker=ticker,
+                catalog=catalog_name,
+                reason="no catalog_instruments row — company profiles not loaded?",
+            )
+            return None
+
+        qid = self.qualified_instrument_id(ticker, venue)
+        instrument.nautilus_id = str(qid) if qid is not None else None
+        instrument.exchange = venue
+        self._repo.upsert(instrument)
+        logger.debug(
+            "qualification_synced",
+            ticker=ticker,
+            venue=venue,
+            nautilus_id=instrument.nautilus_id,
+        )
+        return qid
+
     def resolve_instrument_id(self, ticker: str, catalog_name: str) -> InstrumentId:
         """Look up ticker in DB and return Nautilus InstrumentId.
 

--- a/src/services/firstrate/instrument_mapper.py
+++ b/src/services/firstrate/instrument_mapper.py
@@ -148,7 +148,11 @@ class InstrumentMapper:
         ``catalog_instruments`` identity row and recomputes ``nautilus_id``. ``instrument_metadata``
         stays the source of truth for resolved metadata; ``catalog_instruments`` for bar
         counts/date ranges. A ``VENUE_UNRESOLVED`` ticker (``venue is None``) leaves
-        ``nautilus_id`` ``None`` — unqualified, not fabricated (AC3; excludes/flag are Story 3.5).
+        ``nautilus_id`` ``None`` — unqualified, not fabricated (AC3). Nulling the identity is
+        the exclusion mechanism the backtest loader honors (it gates on ``nautilus_id``), so an
+        unresolved-venue ticker is kept out of every backtest; the on-disk Parquet is untouched
+        (Story 3.5 AC2 — bars present, not dropped), just unreachable-by-id until the venue
+        resolves and this re-runs with a real venue. See ``backtest_loader.load_from_catalog``.
 
         Args:
             ticker: Trading symbol.

--- a/src/services/metadata/backtestable.py
+++ b/src/services/metadata/backtestable.py
@@ -1,0 +1,62 @@
+"""Pure backtestable-universe classification (Story 3.5).
+
+Domain-facing, side-effect-free helpers for the exclude/flag/keep-bars contract:
+a ticker is backtestable iff its venue is ``RESOLVED``. The universe is a live
+derivation over ``instrument_metadata.resolution_status`` — never a stored flag
+and never read off ``catalog_instruments.nautilus_id`` (which the orphan fix in
+``instrument_mapper.sync_qualification`` may deliberately keep provisional). The
+CLI (``metadata backtestable``) renders these; this module owns only the math.
+"""
+
+from dataclasses import dataclass
+
+from src.db.models.catalog_instrument import CatalogInstrument
+from src.models.instrument_metadata import ResolutionStatus
+
+#: The five per-timeframe bar-count columns summed by ``total_bars``.
+_BAR_COUNT_FIELDS = (
+    "bar_count_daily",
+    "bar_count_hourly",
+    "bar_count_minute",
+    "bar_count_5min",
+    "bar_count_30min",
+)
+
+
+def is_backtestable(status: ResolutionStatus) -> bool:
+    """True iff the venue verdict admits the ticker to the backtestable universe.
+
+    Backtestable ⟺ ``RESOLVED`` (venue known). ``VENUE_UNRESOLVED`` (the gate
+    blocker) and ``UNRESOLVED`` (never attempted) are both non-backtestable, so
+    no venue is ever guessed to admit a ticker.
+    """
+    return status == ResolutionStatus.RESOLVED
+
+
+def total_bars(instrument: CatalogInstrument) -> int:
+    """Sum the five per-timeframe bar counts (unset/``None`` counts count as 0).
+
+    Evidence that an excluded ticker's imported bars are retained (excluded ≠
+    dropped). A freshly-constructed ORM row has ``None`` counts (defaults apply
+    at INSERT), so each is coerced to 0.
+    """
+    return sum(int(getattr(instrument, field) or 0) for field in _BAR_COUNT_FIELDS)
+
+
+@dataclass(frozen=True)
+class NonBacktestableTicker:
+    """A flagged non-backtestable ticker + the bars still retained for it.
+
+    Attributes:
+        ticker: The excluded ticker (venue unresolved).
+        bars_retained: Total imported bars still on disk for it (0 if it has no
+            ``catalog_instruments`` row — fresh unresolved, nothing to lose).
+    """
+
+    ticker: str
+    bars_retained: int
+
+    @property
+    def bars_kept(self) -> bool:
+        """True when imported bars are retained for this excluded ticker."""
+        return self.bars_retained > 0

--- a/src/services/metadata/coverage_report.py
+++ b/src/services/metadata/coverage_report.py
@@ -1,0 +1,63 @@
+"""Pure venue-coverage aggregate for the completeness gate (Story 3.4).
+
+Domain-facing math over the per-status counts produced by
+``SyncInstrumentMetadataRepository.count_by_status`` — no I/O, no clock, no Click.
+The CLI (``metadata coverage``) renders this and owns the process exit code; this
+module owns only the coverage percentage and the pass/fail verdict.
+"""
+
+from dataclasses import dataclass
+
+from src.models.instrument_metadata import ResolutionStatus
+
+
+@dataclass(frozen=True)
+class VenueCoverage:
+    """Venue-coverage snapshot + completeness verdict.
+
+    ``coverage_pct`` is measured over ``decided`` (RESOLVED + VENUE_UNRESOLVED),
+    NOT ``total`` — never-attempted ``UNRESOLVED`` rows are surfaced separately
+    but kept out of the ratio, so the gate identity holds exactly:
+    ``is_complete`` ⟺ ``coverage_pct == 100.0``.
+
+    Attributes:
+        resolved: Rows with a known venue (backtestable).
+        venue_unresolved: Rows resolution ran on but could not assign a venue —
+            the gate blocker.
+        unresolved: Rows resolution has not yet been attempted for (transient).
+    """
+
+    resolved: int
+    venue_unresolved: int
+    unresolved: int
+
+    @classmethod
+    def from_counts(cls, counts: dict[ResolutionStatus, int]) -> "VenueCoverage":
+        """Build from a status→count map (absent statuses default to 0)."""
+        return cls(
+            resolved=counts.get(ResolutionStatus.RESOLVED, 0),
+            venue_unresolved=counts.get(ResolutionStatus.VENUE_UNRESOLVED, 0),
+            unresolved=counts.get(ResolutionStatus.UNRESOLVED, 0),
+        )
+
+    @property
+    def decided(self) -> int:
+        """Rows resolution has reached a venue verdict on (coverage denominator)."""
+        return self.resolved + self.venue_unresolved
+
+    @property
+    def total(self) -> int:
+        """All metadata rows across every status."""
+        return self.resolved + self.venue_unresolved + self.unresolved
+
+    @property
+    def coverage_pct(self) -> float:
+        """Percent of decided rows with a venue; 100.0 when nothing is decided."""
+        if self.decided == 0:
+            return 100.0
+        return self.resolved / self.decided * 100
+
+    @property
+    def is_complete(self) -> bool:
+        """The completeness gate: no ticker left VENUE_UNRESOLVED (no venue guessed)."""
+        return self.venue_unresolved == 0

--- a/src/services/metadata/unresolved_report.py
+++ b/src/services/metadata/unresolved_report.py
@@ -1,0 +1,32 @@
+"""Derivation for the Story 3.2 unresolved-venue report.
+
+Pure, side-effect-free classification of *why* a ``VENUE_UNRESOLVED`` row lacks
+a venue, derived from the persisted ``instrument_metadata`` row alone. The raw
+FMP ``exchange`` label is never stored (``normalize_venue`` collapses blank,
+ambiguous, and unmapped labels all to ``venue=None``), so the reason is a
+deliberately best-effort two-way classification — see the module docstring in
+``providers/fmp_provider.py`` for the two paths this discriminates.
+"""
+
+from src.db.models.instrument_metadata import InstrumentMetadata
+
+
+def unresolved_reason(md: InstrumentMetadata) -> str:
+    """Return a human-readable reason a ticker's venue is unresolved.
+
+    Discriminates the FMP provider's two ``VENUE_UNRESOLVED`` paths using
+    ``asset_type``: ``_degraded`` (unknown ticker / no profile) leaves it
+    ``None``, while ``_to_domain`` (profile found, exchange label blank or
+    ambiguous) always assigns a concrete ``AssetType``.
+
+    Args:
+        md: A persisted ``VENUE_UNRESOLVED`` metadata row.
+
+    Returns:
+        A best-effort reason string, provider-agnostic via
+        ``md.metadata_provider``.
+    """
+    provider = md.metadata_provider
+    if md.asset_type is None:
+        return f"unknown to {provider} — no profile returned"
+    return f"{provider} venue label blank, ambiguous (e.g. AMEX), or unmapped"

--- a/src/services/metadata/venue_overrides.py
+++ b/src/services/metadata/venue_overrides.py
@@ -1,0 +1,149 @@
+"""Manual venue corrections: load ``venue_overrides.csv`` and merge with precedence (Story 3.3).
+
+The operator supplies venues the conservative FMP map (ADR-6) could not resolve
+in a git-tracked ``venue_overrides.csv`` (header exactly ``ticker,venue``). This
+module owns the pure CSV parse (``load_venue_overrides``) and the store-merge
+orchestration (``merge_venue_overrides``) that flips matching rows to
+``RESOLVED`` with the override venue taking precedence.
+
+The merge is an import-orchestration concern layered over the persisted metadata
+rows — it never calls ``FMPClient`` / the provider, and the clock is passed in by
+the caller so unchanged rows stay untouched (idempotent re-runs).
+"""
+
+import csv
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+from pydantic import BaseModel
+
+from src.db.repositories.instrument_metadata_repository_sync import (
+    SyncInstrumentMetadataRepository,
+)
+from src.models.instrument_metadata import NA_SENTINEL
+
+logger = structlog.get_logger(__name__)
+
+#: The exact header the override file must carry (cells compared case-insensitively).
+_EXPECTED_HEADER = ["ticker", "venue"]
+
+#: Max venue length — matches the ``instrument_metadata.venue`` ``String(20)`` column;
+#: a longer value is a typo/garbage, skipped at load rather than failing at write time.
+_MAX_VENUE_LEN = 20
+
+
+class VenueOverrideError(Exception):
+    """Raised on a malformed override file (header not exactly ``ticker,venue``)."""
+
+
+class VenueOverrideMergeResult(BaseModel):
+    """Outcome tally for a ``merge_venue_overrides`` run.
+
+    Attributes:
+        applied: Rows whose venue/status were changed by an override.
+        unchanged: Rows already at the override target (idempotent no-write).
+        unmatched: Override tickers with no ``instrument_metadata`` row (surfaced,
+            never fabricated).
+    """
+
+    applied: int = 0
+    unchanged: int = 0
+    unmatched: list[str] = []
+
+    @property
+    def total(self) -> int:
+        """Total overrides processed across all three outcomes."""
+        return self.applied + self.unchanged + len(self.unmatched)
+
+
+def load_venue_overrides(path: Path) -> dict[str, str]:
+    """Parse ``venue_overrides.csv`` into a ``{TICKER: VENUE}`` map (pure).
+
+    A missing or empty file returns ``{}`` (overrides are optional; an absent,
+    empty, or header-only file must never break an import). A present-but-wrong
+    header, or a file that cannot be read/decoded (bad bytes, embedded NUL,
+    permission error), raises ``VenueOverrideError`` so both callers degrade to a
+    single warning uniformly. Data rows are normalized (ticker/venue upper-cased,
+    trimmed); a row with a blank ticker, a blank venue, a venue equal to
+    ``NA_SENTINEL``, or a venue longer than the ``venue`` column is skipped (an
+    unfilled/garbage worklist line is not an error). Duplicate tickers: last wins.
+
+    Args:
+        path: Path to the override CSV.
+
+    Returns:
+        Mapping of normalized ticker to normalized venue code.
+
+    Raises:
+        VenueOverrideError: If the header is present but not exactly
+            ``ticker,venue``, or the file cannot be read/decoded/parsed.
+    """
+    if not path.exists():
+        return {}
+
+    overrides: dict[str, str] = {}
+    try:
+        with path.open(encoding="utf-8-sig", newline="") as handle:
+            reader = csv.reader(handle)
+            header = next(reader, None)
+            if header is None:
+                return {}  # empty file — treated as a no-op, like an absent/header-only file
+            if [c.strip().lower() for c in header] != _EXPECTED_HEADER:
+                raise VenueOverrideError(
+                    f"venue_overrides header must be exactly 'ticker,venue' (got: {header!r})"
+                )
+            for row in reader:
+                _merge_row(row, overrides)
+    except (OSError, UnicodeDecodeError, csv.Error) as exc:
+        # A malformed/unreadable file degrades like a bad header — never a raw traceback.
+        raise VenueOverrideError(f"venue_overrides could not be read: {exc}") from exc
+    return overrides
+
+
+def _merge_row(row: list[str], overrides: dict[str, str]) -> None:
+    """Normalize and fold one CSV data row into ``overrides`` (skip unusable rows)."""
+    if len(row) < 2:
+        return
+    ticker = row[0].strip().upper()
+    venue = row[1].strip().upper()
+    if not ticker or not venue or venue == NA_SENTINEL or len(venue) > _MAX_VENUE_LEN:
+        logger.debug("venue_override_row_skipped", ticker=ticker or None, venue=venue or None)
+        return
+    if ticker in overrides and overrides[ticker] != venue:
+        logger.warning(
+            "venue_override_shadowed", ticker=ticker, kept=venue, dropped=overrides[ticker]
+        )
+    overrides[ticker] = venue
+
+
+def merge_venue_overrides(
+    overrides: dict[str, str],
+    repository: SyncInstrumentMetadataRepository,
+    resolved_at: datetime,
+) -> VenueOverrideMergeResult:
+    """Merge overrides into ``instrument_metadata`` with precedence, tallying outcomes.
+
+    Iterates tickers in sorted order (deterministic) and delegates each to
+    ``repository.apply_venue_override`` (which flips a matching row to ``RESOLVED``
+    or reports ``unchanged``/``unmatched``). The clock is threaded in via
+    ``resolved_at`` — the caller stamps it once so unchanged rows never churn.
+
+    Args:
+        overrides: ``{TICKER: VENUE}`` map from ``load_venue_overrides``.
+        repository: Sync metadata repository backing the store.
+        resolved_at: Timestamp recorded on rows the merge changes.
+
+    Returns:
+        The applied/unchanged/unmatched tally.
+    """
+    result = VenueOverrideMergeResult()
+    for ticker, venue in sorted(overrides.items()):
+        outcome = repository.apply_venue_override(ticker, venue, resolved_at)
+        if outcome == "applied":
+            result.applied += 1
+        elif outcome == "unchanged":
+            result.unchanged += 1
+        else:
+            result.unmatched.append(ticker)
+    return result

--- a/tests/component/db/test_instrument_metadata_repository.py
+++ b/tests/component/db/test_instrument_metadata_repository.py
@@ -293,6 +293,59 @@ class TestSyncInstrumentMetadataRepository:
         with pytest.raises(DatabaseConnectionError):
             repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED)
 
+    def test_count_by_status_groups_and_counts(self, sync_session):
+        """count_by_status returns a per-status count map (Story 3.4)."""
+        repo = SyncInstrumentMetadataRepository(sync_session)
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(ticker="AAA", resolution_status=ResolutionStatus.RESOLVED)
+            )
+        )
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(ticker="BBB", resolution_status=ResolutionStatus.RESOLVED)
+            )
+        )
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(
+                    ticker="CCC", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
+                )
+            )
+        )
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(ticker="DDD", resolution_status=ResolutionStatus.UNRESOLVED)
+            )
+        )
+        sync_session.commit()
+
+        assert repo.count_by_status() == {
+            ResolutionStatus.RESOLVED: 2,
+            ResolutionStatus.VENUE_UNRESOLVED: 1,
+            ResolutionStatus.UNRESOLVED: 1,
+        }
+
+    def test_count_by_status_empty_returns_empty_dict(self, sync_session):
+        """count_by_status returns {} when the store is empty."""
+        repo = SyncInstrumentMetadataRepository(sync_session)
+        assert repo.count_by_status() == {}
+
+    def test_count_by_status_translates_operational_error(self):
+        """A DB OperationalError becomes DatabaseConnectionError (mirrors upsert)."""
+        from unittest.mock import MagicMock
+
+        from sqlalchemy.exc import OperationalError
+
+        from src.db.exceptions import DatabaseConnectionError
+
+        session = MagicMock()
+        session.execute.side_effect = OperationalError("SELECT ...", {}, Exception("down"))
+        repo = SyncInstrumentMetadataRepository(session)
+
+        with pytest.raises(DatabaseConnectionError):
+            repo.count_by_status()
+
     def test_apply_venue_override_flips_unresolved_to_resolved(self, sync_session):
         """An override sets venue + RESOLVED on an existing VENUE_UNRESOLVED row (Story 3.3)."""
         from datetime import datetime, timezone

--- a/tests/component/db/test_instrument_metadata_repository.py
+++ b/tests/component/db/test_instrument_metadata_repository.py
@@ -292,3 +292,68 @@ class TestSyncInstrumentMetadataRepository:
 
         with pytest.raises(DatabaseConnectionError):
             repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED)
+
+    def test_apply_venue_override_flips_unresolved_to_resolved(self, sync_session):
+        """An override sets venue + RESOLVED on an existing VENUE_UNRESOLVED row (Story 3.3)."""
+        from datetime import datetime, timezone
+
+        repo = SyncInstrumentMetadataRepository(sync_session)
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(
+                    ticker="SPY", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
+                )
+            )
+        )
+        sync_session.commit()
+
+        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
+        outcome = repo.apply_venue_override("SPY", "ARCA", ts)
+        sync_session.commit()
+
+        assert outcome == "applied"
+        row = repo.get_by_ticker("SPY")
+        assert row is not None
+        assert row.venue == "ARCA"
+        assert row.resolution_status == ResolutionStatus.RESOLVED
+        # SQLite's TIMESTAMP column round-trips tz-naive; compare the wall value.
+        assert row.resolved_at == ts.replace(tzinfo=None)
+
+    def test_apply_venue_override_is_idempotent(self, sync_session):
+        """Re-applying the same override is a no-op — no resolved_at churn (AC3)."""
+        from datetime import datetime, timezone
+
+        repo = SyncInstrumentMetadataRepository(sync_session)
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(
+                    ticker="SPY", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
+                )
+            )
+        )
+        sync_session.commit()
+
+        ts1 = datetime(2026, 7, 13, tzinfo=timezone.utc)
+        repo.apply_venue_override("SPY", "ARCA", ts1)
+        sync_session.commit()
+
+        ts2 = datetime(2026, 7, 14, tzinfo=timezone.utc)
+        outcome = repo.apply_venue_override("SPY", "ARCA", ts2)
+        sync_session.commit()
+
+        assert outcome == "unchanged"
+        row = repo.get_by_ticker("SPY")
+        assert row is not None
+        assert row.resolved_at == ts1.replace(tzinfo=None)  # not overwritten by 2nd call
+
+    def test_apply_venue_override_unmatched_ticker(self, sync_session):
+        """An override for an absent ticker returns 'unmatched' and creates no row."""
+        from datetime import datetime, timezone
+
+        repo = SyncInstrumentMetadataRepository(sync_session)
+        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
+
+        outcome = repo.apply_venue_override("NOPE", "ARCA", ts)
+
+        assert outcome == "unmatched"
+        assert repo.get_by_ticker("NOPE") is None

--- a/tests/component/db/test_instrument_metadata_repository.py
+++ b/tests/component/db/test_instrument_metadata_repository.py
@@ -232,3 +232,63 @@ class TestSyncInstrumentMetadataRepository:
         result = repo.get_by_ticker("SPY")
         assert result is not None
         assert result.resolution_status == ResolutionStatus.UNRESOLVED
+
+    def test_list_by_status_filters_and_orders(self, sync_session):
+        """list_by_status returns only matching rows, ordered by ticker (Story 3.2)."""
+        repo = SyncInstrumentMetadataRepository(sync_session)
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(ticker="AAA", resolution_status=ResolutionStatus.RESOLVED)
+            )
+        )
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(
+                    ticker="CCC", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
+                )
+            )
+        )
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(
+                    ticker="BBB", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
+                )
+            )
+        )
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(ticker="DDD", resolution_status=ResolutionStatus.UNRESOLVED)
+            )
+        )
+        sync_session.commit()
+
+        rows = repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED)
+
+        assert [r.ticker for r in rows] == ["BBB", "CCC"]
+
+    def test_list_by_status_empty_returns_empty_list(self, sync_session):
+        """list_by_status returns [] when no rows match the status."""
+        repo = SyncInstrumentMetadataRepository(sync_session)
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(ticker="AAA", resolution_status=ResolutionStatus.RESOLVED)
+            )
+        )
+        sync_session.commit()
+
+        assert repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED) == []
+
+    def test_list_by_status_translates_operational_error(self):
+        """A DB OperationalError becomes DatabaseConnectionError (mirrors upsert)."""
+        from unittest.mock import MagicMock
+
+        from sqlalchemy.exc import OperationalError
+
+        from src.db.exceptions import DatabaseConnectionError
+
+        session = MagicMock()
+        session.execute.side_effect = OperationalError("SELECT ...", {}, Exception("down"))
+        repo = SyncInstrumentMetadataRepository(session)
+
+        with pytest.raises(DatabaseConnectionError):
+            repo.list_by_status(ResolutionStatus.VENUE_UNRESOLVED)

--- a/tests/component/db/test_instrument_metadata_repository.py
+++ b/tests/component/db/test_instrument_metadata_repository.py
@@ -410,3 +410,42 @@ class TestSyncInstrumentMetadataRepository:
 
         assert outcome == "unmatched"
         assert repo.get_by_ticker("NOPE") is None
+
+    def test_venue_override_transitions_ticker_to_backtestable(self, sync_session):
+        """Story 3.5 AC3: an override flips a non-backtestable ticker into the universe."""
+        from datetime import datetime, timezone
+
+        from src.services.metadata.backtestable import is_backtestable
+
+        repo = SyncInstrumentMetadataRepository(sync_session)
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(
+                    ticker="AAA", venue="XNAS", resolution_status=ResolutionStatus.RESOLVED
+                )
+            )
+        )
+        repo.upsert(
+            InstrumentMetadata(
+                **_make_metadata(
+                    ticker="ZZZ", venue=None, resolution_status=ResolutionStatus.VENUE_UNRESOLVED
+                )
+            )
+        )
+        sync_session.commit()
+
+        # Before: only AAA is backtestable; ZZZ is excluded and flagged.
+        backtestable = repo.list_by_status(ResolutionStatus.RESOLVED)
+        assert [r.ticker for r in backtestable] == ["AAA"]
+        zzz = repo.get_by_ticker("ZZZ")
+        assert is_backtestable(zzz.resolution_status) is False
+
+        # Transition: resolve the venue via the Story 3.3 override (no bar/import op).
+        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
+        assert repo.apply_venue_override("ZZZ", "ARCA", ts) == "applied"
+        sync_session.commit()
+
+        # After: ZZZ is now in the backtestable universe, derived from the flipped status.
+        backtestable = repo.list_by_status(ResolutionStatus.RESOLVED)
+        assert sorted(r.ticker for r in backtestable) == ["AAA", "ZZZ"]
+        assert is_backtestable(repo.get_by_ticker("ZZZ").resolution_status) is True

--- a/tests/component/services/firstrate/test_import_service.py
+++ b/tests/component/services/firstrate/test_import_service.py
@@ -540,6 +540,10 @@ class TestIdempotentRerun:
             aapl_row.date_range_end = stateful_metadata_service._datetime(
                 2024, 12, 31, tzinfo=stateful_metadata_service._tz
             )
+            # The per-timeframe classifier (commit d75a409) compares the
+            # timeframe's own date_range_end_daily, not the shared
+            # date_range_end — rewind that too so AAPL is genuinely incomplete.
+            aapl_row.date_range_end_daily = aapl_row.date_range_end
             aapl_row.bar_count_daily = 5
 
             # SPY stays "complete" and must be skipped on re-run; its
@@ -1175,6 +1179,10 @@ class TestStory26IdempotentRerun:
             aapl_row.date_range_end = stateful_metadata_service._datetime(
                 2024, 12, 31, tzinfo=stateful_metadata_service._tz
             )
+            # The per-timeframe classifier (commit d75a409) compares the
+            # timeframe's own date_range_end_daily, not the shared
+            # date_range_end — rewind that too so AAPL is genuinely incomplete.
+            aapl_row.date_range_end_daily = aapl_row.date_range_end
             aapl_row.bar_count_daily = 5
 
             writes_before_rerun = mock_catalog.write_data.call_count
@@ -1228,6 +1236,10 @@ class TestStory26IdempotentRerun:
             aapl_row.date_range_end = stateful_metadata_service._datetime(
                 2024, 12, 31, tzinfo=stateful_metadata_service._tz
             )
+            # The per-timeframe classifier (commit d75a409) compares the
+            # timeframe's own date_range_end_daily, not the shared
+            # date_range_end — rewind that too so AAPL is genuinely incomplete.
+            aapl_row.date_range_end_daily = aapl_row.date_range_end
             aapl_row.bar_count_daily = 5
 
             # Run 2: a brand-new service (fresh in-run dedup) sharing the SAME

--- a/tests/component/services/firstrate/test_instrument_mapper.py
+++ b/tests/component/services/firstrate/test_instrument_mapper.py
@@ -34,6 +34,11 @@ CREATE TABLE IF NOT EXISTS catalog_instruments (
     state VARCHAR(100),
     date_range_start TIMESTAMP,
     date_range_end TIMESTAMP,
+    date_range_end_daily TIMESTAMP,
+    date_range_end_hourly TIMESTAMP,
+    date_range_end_minute TIMESTAMP,
+    date_range_end_5min TIMESTAMP,
+    date_range_end_30min TIMESTAMP,
     bar_count_daily INTEGER NOT NULL DEFAULT 0,
     bar_count_hourly INTEGER NOT NULL DEFAULT 0,
     bar_count_minute INTEGER NOT NULL DEFAULT 0,
@@ -167,3 +172,36 @@ class TestInstrumentMapperDBRoundTrip:
         for ticker, expected_id in expected.items():
             result = mapper.resolve_instrument_id(ticker, CATALOG_NAME)
             assert result == InstrumentId.from_str(expected_id)
+
+
+class TestQualificationSync:
+    """Story 3.1: ADR-3 qualification sync round-trips through the real repo."""
+
+    @pytest.mark.component
+    def test_sync_overwrites_provisional_exchange_with_resolved_venue(self, mapper, repo, tmp_path):
+        """Resolved venue overwrites the provisional CSV exchange and recomputes id."""
+        # Seed the row with a provisional (wrong) CSV exchange.
+        csv = tmp_path / "profiles.csv"
+        csv.write_text(
+            "SPY,SPDR S&P 500 ETF Trust,US,NY,NYSE,Financial Services,Asset Management,1993-01-22\n"
+        )
+        mapper.load_company_profiles(csv, CATALOG_NAME, ASSET_CLASS)
+        assert repo.get_by_ticker(CATALOG_NAME, "SPY").nautilus_id == "SPY.NYSE"
+
+        result = mapper.sync_qualification("SPY", CATALOG_NAME, "ARCA")
+
+        assert result == InstrumentId.from_str("SPY.ARCA")
+        persisted = repo.get_by_ticker(CATALOG_NAME, "SPY")
+        assert persisted.nautilus_id == "SPY.ARCA"
+        assert persisted.exchange == "ARCA"
+
+    @pytest.mark.component
+    def test_sync_unresolved_persists_null_nautilus_id(self, mapper, repo, company_profiles_csv):
+        """An unresolved (None) venue persists nautilus_id NULL (unqualified, not fabricated)."""
+        mapper.load_company_profiles(company_profiles_csv, CATALOG_NAME, ASSET_CLASS)
+
+        result = mapper.sync_qualification("SPY", CATALOG_NAME, None)
+
+        assert result is None
+        persisted = repo.get_by_ticker(CATALOG_NAME, "SPY")
+        assert persisted.nautilus_id is None

--- a/tests/unit/cli/commands/test_import_data.py
+++ b/tests/unit/cli/commands/test_import_data.py
@@ -1011,3 +1011,87 @@ class TestStory17ProgressAndSummary:
             ),
         ]
         assert determine_exit_code(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Story 3.3: venue-override merge wiring (_apply_venue_overrides)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestApplyVenueOverrides:
+    """The import-orchestration helper that merges venue_overrides.csv."""
+
+    def _settings(self, path: str):
+        from unittest.mock import MagicMock
+
+        settings = MagicMock()
+        settings.firstrate.firstrate_venue_overrides_path = path
+        return settings
+
+    def test_empty_file_is_silent_noop(self, capsys):
+        from src.cli.commands.import_data import _apply_venue_overrides
+
+        with patch("src.services.metadata.venue_overrides.load_venue_overrides", return_value={}):
+            _apply_venue_overrides(object(), self._settings("venue_overrides.csv"))
+        assert "Venue overrides" not in capsys.readouterr().out
+
+    def test_non_empty_prints_summary(self, capsys):
+        from src.cli.commands.import_data import _apply_venue_overrides
+        from src.services.metadata.venue_overrides import VenueOverrideMergeResult
+
+        with (
+            patch(
+                "src.services.metadata.venue_overrides.load_venue_overrides",
+                return_value={"SPY": "ARCA"},
+            ),
+            patch(
+                "src.services.metadata.venue_overrides.merge_venue_overrides",
+                return_value=VenueOverrideMergeResult(applied=1),
+            ),
+            patch(
+                "src.db.repositories.instrument_metadata_repository_sync."
+                "SyncInstrumentMetadataRepository"
+            ),
+        ):
+            _apply_venue_overrides(object(), self._settings("venue_overrides.csv"))
+        assert "1 applied" in capsys.readouterr().out
+
+    def test_unmatched_tickers_listed(self, capsys):
+        from src.cli.commands.import_data import _apply_venue_overrides
+        from src.services.metadata.venue_overrides import VenueOverrideMergeResult
+
+        with (
+            patch(
+                "src.services.metadata.venue_overrides.load_venue_overrides",
+                return_value={"ZZZ": "ARCA"},
+            ),
+            patch(
+                "src.services.metadata.venue_overrides.merge_venue_overrides",
+                return_value=VenueOverrideMergeResult(unmatched=["ZZZ"]),
+            ),
+            patch(
+                "src.db.repositories.instrument_metadata_repository_sync."
+                "SyncInstrumentMetadataRepository"
+            ),
+        ):
+            _apply_venue_overrides(object(), self._settings("venue_overrides.csv"))
+        out = capsys.readouterr().out
+        assert "1 unmatched" in out
+        assert "ZZZ" in out
+
+    def test_malformed_header_warns_and_skips_without_markup_crash(self, capsys):
+        # The real VenueOverrideError message embeds the header repr, which always
+        # contains '[' / ']'. Without escaping, Rich would raise MarkupError and the
+        # exception would propagate out of _apply_venue_overrides, rolling back the
+        # in-flight import. This exercises the escape() fix (must NOT raise).
+        from src.cli.commands.import_data import _apply_venue_overrides
+        from src.services.metadata.venue_overrides import VenueOverrideError
+
+        msg = "venue_overrides header must be exactly 'ticker,venue' (got: ['symbol', 'exchange'])"
+        with patch(
+            "src.services.metadata.venue_overrides.load_venue_overrides",
+            side_effect=VenueOverrideError(msg),
+        ):
+            _apply_venue_overrides(object(), self._settings("venue_overrides.csv"))
+        assert "not applied" in capsys.readouterr().out

--- a/tests/unit/cli/commands/test_import_reporting.py
+++ b/tests/unit/cli/commands/test_import_reporting.py
@@ -212,3 +212,26 @@ class TestPrintSummaryVerification:
     def test_smoke_call_with_warnings_does_not_raise(self):
         results = [_success("SPY", warnings=["bar[0] ts=42: high (90.0) < low (95.0)"])]
         import_reporting._print_summary(results)
+
+
+class TestProgressLineSkipReason:
+    """_print_progress_line distinguishes idempotent vs venue-unresolved skips."""
+
+    def test_idempotent_skip_says_already_complete(self, capsys):
+        result = ImportResult(ticker="SPY", status="skipped", outcome="skipped", duration=0.1)
+        import_reporting._print_progress_line(result, "1-DAY-LAST")
+        out = capsys.readouterr().out
+        assert "skipped (already complete)" in out
+
+    def test_unresolved_skip_shows_reason(self, capsys):
+        result = ImportResult(
+            ticker="ZZZ",
+            status="skipped",
+            outcome="skipped",
+            error="venue unresolved — deferred to Story 3.5",
+            duration=0.1,
+        )
+        import_reporting._print_progress_line(result, "1-DAY-LAST")
+        out = capsys.readouterr().out
+        assert "venue unresolved" in out
+        assert "already complete" not in out

--- a/tests/unit/cli/commands/test_metadata.py
+++ b/tests/unit/cli/commands/test_metadata.py
@@ -191,6 +191,152 @@ class TestMetadataApplyOverrides:
 
 
 @pytest.mark.unit
+class TestMetadataCoverage:
+    """`metadata coverage` report + completeness gate (Story 3.4)."""
+
+    def test_complete_no_flag_reports_pass(self, runner):
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.count_by_status.return_value = {ResolutionStatus.RESOLVED: 3}
+            result = runner.invoke(metadata, ["coverage"])
+
+        assert result.exit_code == 0
+        assert "100.0%" in result.output
+        assert "COMPLETE" in result.output
+        assert "gate PASS" in result.output
+
+    def test_incomplete_no_flag_reports_fail_but_exits_zero(self, runner):
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.count_by_status.return_value = {
+                ResolutionStatus.RESOLVED: 2,
+                ResolutionStatus.VENUE_UNRESOLVED: 1,
+            }
+            result = runner.invoke(metadata, ["coverage"])
+
+        assert result.exit_code == 0  # report-only without --gate
+        assert "INCOMPLETE" in result.output
+        assert "gate FAIL" in result.output
+        assert "66.7%" in result.output
+        assert "1 ticker(s) VENUE_UNRESOLVED" in result.output
+
+    def test_incomplete_gate_exits_one(self, runner):
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.count_by_status.return_value = {
+                ResolutionStatus.RESOLVED: 2,
+                ResolutionStatus.VENUE_UNRESOLVED: 1,
+            }
+            result = runner.invoke(metadata, ["coverage", "--gate"])
+
+        assert result.exit_code == 1  # AC2 — scriptable FAIL
+        assert "INCOMPLETE" in result.output
+
+    def test_complete_gate_exits_zero(self, runner):
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.count_by_status.return_value = {ResolutionStatus.RESOLVED: 3}
+            result = runner.invoke(metadata, ["coverage", "--gate"])
+
+        assert result.exit_code == 0  # AC3
+        assert "gate PASS" in result.output
+
+    def test_db_unconfigured_no_flag_degrades_gracefully(self, runner):
+        ctx = MagicMock()
+        ctx.__enter__.side_effect = RuntimeError("Database not configured")
+        with patch("src.cli.commands.metadata.get_sync_session", return_value=ctx):
+            result = runner.invoke(metadata, ["coverage"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert "Metadata DB not available" in result.output
+
+    def test_db_unconfigured_gate_exits_two(self, runner):
+        """Under --gate a DB that cannot be read must NOT be treated as passing (AC4)."""
+        ctx = MagicMock()
+        ctx.__enter__.side_effect = RuntimeError("Database not configured")
+        with patch("src.cli.commands.metadata.get_sync_session", return_value=ctx):
+            result = runner.invoke(metadata, ["coverage", "--gate"])
+
+        assert result.exit_code == 2  # could-not-evaluate ≠ pass
+        assert "Metadata DB not available" in result.output
+
+    def test_db_query_error_gate_exits_two(self, runner):
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.count_by_status.side_effect = OperationalError(
+                "SELECT ...", {}, Exception("connection refused")
+            )
+            result = runner.invoke(metadata, ["coverage", "--gate"])
+
+        assert result.exit_code == 2
+        assert "Metadata DB not available" in result.output
+
+
+@pytest.mark.unit
+class TestRenderCoverage:
+    """Direct render-helper tests (no CliRunner)."""
+
+    def test_render_incomplete_shows_counts_pct_and_fail(self, capsys):
+        from src.cli.commands.metadata import _render_coverage
+        from src.services.metadata.coverage_report import VenueCoverage
+
+        cov = VenueCoverage.from_counts(
+            {ResolutionStatus.RESOLVED: 2, ResolutionStatus.VENUE_UNRESOLVED: 1}
+        )
+        _render_coverage(cov)
+        out = capsys.readouterr().out
+        assert "66.7%" in out
+        assert "INCOMPLETE" in out
+        assert "gate FAIL" in out
+
+    def test_render_complete_shows_pass(self, capsys):
+        from src.cli.commands.metadata import _render_coverage
+        from src.services.metadata.coverage_report import VenueCoverage
+
+        _render_coverage(VenueCoverage.from_counts({ResolutionStatus.RESOLVED: 4}))
+        out = capsys.readouterr().out
+        assert "100.0%" in out
+        assert "COMPLETE" in out
+        assert "gate PASS" in out
+
+    def test_render_empty_shows_no_rows_note(self, capsys):
+        from src.cli.commands.metadata import _render_coverage
+        from src.services.metadata.coverage_report import VenueCoverage
+
+        _render_coverage(VenueCoverage.from_counts({}))
+        out = capsys.readouterr().out
+        assert "no metadata rows" in out.lower()
+
+    def test_render_near_complete_never_displays_100pct_while_fail(self, capsys):
+        # Review patch: 9999/10000 rounds to "100.0%" under .1f — the displayed
+        # percent must be clamped so it can't contradict the FAIL verdict.
+        from src.cli.commands.metadata import _render_coverage
+        from src.services.metadata.coverage_report import VenueCoverage
+
+        cov = VenueCoverage.from_counts(
+            {ResolutionStatus.RESOLVED: 9999, ResolutionStatus.VENUE_UNRESOLVED: 1}
+        )
+        _render_coverage(cov)
+        out = capsys.readouterr().out
+        assert "100.0%" not in out
+        assert "99.9%" in out
+        assert "gate FAIL" in out
+
+    def test_render_only_unattempted_flags_vacuous_pass(self, capsys):
+        # Review patch: decided==0 but total>0 (resolution never ran) must carry
+        # the vacuous-PASS caveat, not an un-caveated green COMPLETE.
+        from src.cli.commands.metadata import _render_coverage
+        from src.services.metadata.coverage_report import VenueCoverage
+
+        _render_coverage(VenueCoverage.from_counts({ResolutionStatus.UNRESOLVED: 5}))
+        out = capsys.readouterr().out
+        assert "vacuous" in out.lower()
+        assert "resolution has not run" in out.lower()
+        assert "COMPLETE" in out
+
+
+@pytest.mark.unit
 class TestRegistration:
     """The `metadata` group is wired into the top-level CLI."""
 
@@ -200,6 +346,7 @@ class TestRegistration:
         assert "metadata" in cli.commands
         assert "unresolved" in cli.commands["metadata"].commands
         assert "apply-overrides" in cli.commands["metadata"].commands
+        assert "coverage" in cli.commands["metadata"].commands
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/commands/test_metadata.py
+++ b/tests/unit/cli/commands/test_metadata.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import OperationalError
 
 from src.cli.commands.metadata import _render_unresolved, metadata
 from src.db.exceptions import DatabaseConnectionError
+from src.db.models.catalog_instrument import CatalogInstrument
 from src.db.models.instrument_metadata import InstrumentMetadata
 from src.models.instrument_metadata import NA_SENTINEL, AssetType, ResolutionStatus
 
@@ -347,6 +348,7 @@ class TestRegistration:
         assert "unresolved" in cli.commands["metadata"].commands
         assert "apply-overrides" in cli.commands["metadata"].commands
         assert "coverage" in cli.commands["metadata"].commands
+        assert "backtestable" in cli.commands["metadata"].commands
 
 
 @pytest.mark.unit
@@ -372,3 +374,154 @@ class TestRenderUnresolved:
         _render_unresolved([])
         out = capsys.readouterr().out
         assert "All venues resolved" in out
+
+
+def _catalog_instrument(ticker: str, minute_bars: int) -> CatalogInstrument:
+    return CatalogInstrument(
+        ticker=ticker,
+        asset_class="ETF",
+        catalog_name="firstrate-etf",
+        nautilus_id=f"{ticker}.NYSE",
+        exchange="NYSE",
+        bar_count_minute=minute_bars,
+    )
+
+
+@pytest.mark.unit
+class TestMetadataBacktestable:
+    """`metadata backtestable` report (Story 3.5)."""
+
+    def _patch_both_repos(self):
+        session_patch, meta_patch = _patch_session_and_repo()
+        cat_patch = patch("src.cli.commands.metadata.SyncCatalogInstrumentRepository")
+        return session_patch, meta_patch, cat_patch
+
+    def test_flagged_lists_tickers_and_retained_bars(self, runner):
+        session_patch, meta_patch, cat_patch = self._patch_both_repos()
+        with session_patch, meta_patch as mock_meta, cat_patch as mock_cat:
+            mock_meta.return_value.count_by_status.return_value = {
+                ResolutionStatus.RESOLVED: 3,
+                ResolutionStatus.VENUE_UNRESOLVED: 1,
+            }
+            mock_meta.return_value.list_by_status.return_value = [_degraded_row("ZZZ")]
+            mock_cat.return_value.get_by_ticker.return_value = _catalog_instrument("ZZZ", 100)
+            result = runner.invoke(metadata, ["backtestable"])
+
+        assert result.exit_code == 0
+        assert "ZZZ" in result.output
+        assert "100" in result.output
+        assert "Non-backtestable (venue unresolved): 1" in result.output
+        assert "bars retained" in result.output
+        assert "venue_overrides.csv" in result.output
+
+    def test_all_resolved_shows_all_clear(self, runner):
+        session_patch, meta_patch, cat_patch = self._patch_both_repos()
+        with session_patch, meta_patch as mock_meta, cat_patch:
+            mock_meta.return_value.count_by_status.return_value = {ResolutionStatus.RESOLVED: 5}
+            mock_meta.return_value.list_by_status.return_value = []
+            result = runner.invoke(metadata, ["backtestable"])
+
+        assert result.exit_code == 0
+        assert "0 non-backtestable" in result.output
+        assert "backtestable universe = 5" in result.output
+
+    def test_never_attempted_surfaced_not_hidden_by_all_clear(self, runner):
+        """UNRESOLVED (never-attempted) rows are reported, not masked by a green banner."""
+        session_patch, meta_patch, cat_patch = self._patch_both_repos()
+        with session_patch, meta_patch as mock_meta, cat_patch:
+            mock_meta.return_value.count_by_status.return_value = {
+                ResolutionStatus.RESOLVED: 2,
+                ResolutionStatus.UNRESOLVED: 3,
+            }
+            mock_meta.return_value.list_by_status.return_value = []
+            result = runner.invoke(metadata, ["backtestable"])
+
+        assert result.exit_code == 0
+        assert "All venue-resolved" not in result.output  # not over-claimed
+        assert "Not yet attempted (UNRESOLVED): 3" in result.output
+
+    def test_empty_db_reports_no_rows(self, runner):
+        session_patch, meta_patch, cat_patch = self._patch_both_repos()
+        with session_patch, meta_patch as mock_meta, cat_patch:
+            mock_meta.return_value.count_by_status.return_value = {}
+            mock_meta.return_value.list_by_status.return_value = []
+            result = runner.invoke(metadata, ["backtestable"])
+
+        assert result.exit_code == 0
+        assert "No metadata rows yet" in result.output
+
+    def test_flagged_ticker_without_catalog_row_reports_zero_bars(self, runner):
+        session_patch, meta_patch, cat_patch = self._patch_both_repos()
+        with session_patch, meta_patch as mock_meta, cat_patch as mock_cat:
+            mock_meta.return_value.count_by_status.return_value = {
+                ResolutionStatus.VENUE_UNRESOLVED: 1
+            }
+            mock_meta.return_value.list_by_status.return_value = [_degraded_row("ZZZ")]
+            mock_cat.return_value.get_by_ticker.return_value = None
+            result = runner.invoke(metadata, ["backtestable"])
+
+        assert result.exit_code == 0
+        assert "ZZZ" in result.output
+        assert "Non-backtestable (venue unresolved): 1" in result.output
+
+    def test_catalog_option_overrides_default(self, runner):
+        session_patch, meta_patch, cat_patch = self._patch_both_repos()
+        with session_patch, meta_patch as mock_meta, cat_patch as mock_cat:
+            mock_meta.return_value.count_by_status.return_value = {
+                ResolutionStatus.VENUE_UNRESOLVED: 1
+            }
+            mock_meta.return_value.list_by_status.return_value = [_degraded_row("ZZZ")]
+            mock_cat.return_value.get_by_ticker.return_value = _catalog_instrument("ZZZ", 10)
+            result = runner.invoke(metadata, ["backtestable", "--catalog", "custom-cat"])
+
+        assert result.exit_code == 0
+        mock_cat.return_value.get_by_ticker.assert_called_once_with("custom-cat", "ZZZ")
+
+    def test_db_unconfigured_degrades_gracefully(self, runner):
+        ctx = MagicMock()
+        ctx.__enter__.side_effect = RuntimeError("Database not configured")
+        with patch("src.cli.commands.metadata.get_sync_session", return_value=ctx):
+            result = runner.invoke(metadata, ["backtestable"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert "Metadata DB not available" in result.output
+
+
+@pytest.mark.unit
+class TestRenderBacktestable:
+    """Direct render-helper tests (no CliRunner)."""
+
+    def test_render_flagged_shows_bars_and_summary(self, capsys):
+        from src.cli.commands.metadata import _render_backtestable
+        from src.services.metadata.backtestable import NonBacktestableTicker
+
+        _render_backtestable("firstrate-etf", 3, 0, [NonBacktestableTicker("ZZZ", 100)])
+        out = capsys.readouterr().out
+        assert "ZZZ" in out
+        assert "100" in out
+        assert "Non-backtestable (venue unresolved): 1" in out
+        assert "Backtestable: 3" in out
+
+    def test_render_all_clear_when_no_flagged_and_none_unattempted(self, capsys):
+        from src.cli.commands.metadata import _render_backtestable
+
+        _render_backtestable("firstrate-etf", 7, 0, [])
+        out = capsys.readouterr().out
+        assert "0 non-backtestable" in out
+        assert "7" in out
+
+    def test_render_surfaces_never_attempted(self, capsys):
+        from src.cli.commands.metadata import _render_backtestable
+
+        _render_backtestable("firstrate-etf", 2, 3, [])
+        out = capsys.readouterr().out
+        assert "All venue-resolved" not in out
+        assert "Not yet attempted (UNRESOLVED): 3" in out
+
+    def test_render_empty_reports_no_rows(self, capsys):
+        from src.cli.commands.metadata import _render_backtestable
+
+        _render_backtestable("firstrate-etf", 0, 0, [])
+        out = capsys.readouterr().out
+        assert "No metadata rows yet" in out

--- a/tests/unit/cli/commands/test_metadata.py
+++ b/tests/unit/cli/commands/test_metadata.py
@@ -1,0 +1,153 @@
+"""Unit tests for the `metadata` CLI group (Story 3.2 unresolved-venue report)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from sqlalchemy.exc import OperationalError
+
+from src.cli.commands.metadata import _render_unresolved, metadata
+from src.db.exceptions import DatabaseConnectionError
+from src.db.models.instrument_metadata import InstrumentMetadata
+from src.models.instrument_metadata import NA_SENTINEL, AssetType, ResolutionStatus
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _degraded_row(ticker: str) -> InstrumentMetadata:
+    return InstrumentMetadata(
+        ticker=ticker,
+        metadata_provider="FMP",
+        venue=None,
+        asset_type=None,
+        company_name=NA_SENTINEL,
+        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
+    )
+
+
+def _found_row(ticker: str) -> InstrumentMetadata:
+    return InstrumentMetadata(
+        ticker=ticker,
+        metadata_provider="FMP",
+        venue=None,
+        asset_type=AssetType.ETF.value,
+        company_name="Example ETF",
+        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
+    )
+
+
+def _patch_session_and_repo():
+    """Return (session, repo) patchers backed by a fake sync session."""
+    ctx = MagicMock()
+    ctx.__enter__.return_value = MagicMock()
+    ctx.__exit__.return_value = False
+    session_patch = patch("src.cli.commands.metadata.get_sync_session", return_value=ctx)
+    repo_patch = patch("src.cli.commands.metadata.SyncInstrumentMetadataRepository")
+    return session_patch, repo_patch
+
+
+@pytest.mark.unit
+class TestMetadataUnresolved:
+    """`metadata unresolved` CLI subcommand."""
+
+    def test_populated_lists_tickers_reasons_and_hint(self, runner):
+        rows = [_degraded_row("ZZZ"), _found_row("SPY")]
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.list_by_status.return_value = rows
+            result = runner.invoke(metadata, ["unresolved"])
+
+        assert result.exit_code == 0
+        assert "ZZZ" in result.output
+        assert "SPY" in result.output
+        assert "unknown to FMP" in result.output
+        assert "ambiguous" in result.output
+        assert "2 ticker" in result.output
+        assert "venue_overrides.csv" in result.output
+
+    def test_empty_prints_all_resolved_message(self, runner):
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.list_by_status.return_value = []
+            result = runner.invoke(metadata, ["unresolved"])
+
+        assert result.exit_code == 0
+        assert "All venues resolved" in result.output
+        assert "Ticker" not in result.output  # no table header rendered
+
+    def test_db_unconfigured_degrades_gracefully(self, runner):
+        ctx = MagicMock()
+        ctx.__enter__.side_effect = RuntimeError(
+            "Database not configured. Check DATABASE_URL in .env file"
+        )
+        with patch("src.cli.commands.metadata.get_sync_session", return_value=ctx):
+            result = runner.invoke(metadata, ["unresolved"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert "Metadata DB not available" in result.output  # the warning branch, not a traceback
+
+    def test_db_query_error_degrades_gracefully(self, runner):
+        """A query-time DB failure (Postgres down / table not migrated) → warning, not traceback."""
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.list_by_status.side_effect = OperationalError(
+                "SELECT ...", {}, Exception("connection refused")
+            )
+            result = runner.invoke(metadata, ["unresolved"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert "Metadata DB not available" in result.output
+
+    def test_db_connection_error_degrades_gracefully(self, runner):
+        """The translated DatabaseConnectionError arm is reachable and handled."""
+        session_patch, repo_patch = _patch_session_and_repo()
+        with session_patch, repo_patch as mock_repo:
+            mock_repo.return_value.list_by_status.side_effect = DatabaseConnectionError(
+                "Database connection failed"
+            )
+            result = runner.invoke(metadata, ["unresolved"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert "Metadata DB not available" in result.output
+
+
+@pytest.mark.unit
+class TestRegistration:
+    """The `metadata` group is wired into the top-level CLI."""
+
+    def test_metadata_group_registered_with_unresolved(self):
+        from src.cli.main import cli
+
+        assert "metadata" in cli.commands
+        assert "unresolved" in cli.commands["metadata"].commands
+
+
+@pytest.mark.unit
+class TestRenderUnresolved:
+    """Direct render-helper tests (no CliRunner)."""
+
+    def test_render_preserves_row_order_and_shows_reasons(self, capsys):
+        # Rows arrive pre-ordered by the repo; the renderer must not reshuffle them.
+        _render_unresolved([_found_row("SPY"), _degraded_row("ZZZ")])
+        out = capsys.readouterr().out
+        assert out.index("SPY") < out.index("ZZZ")
+        assert "unknown to FMP" in out
+        assert "unmapped" in out
+
+    def test_render_escapes_markup_in_ticker(self, capsys):
+        # A stray Rich metacharacter in a DB-sourced cell must not raise or mis-render.
+        row = _degraded_row("A[B")
+        _render_unresolved([row])
+        out = capsys.readouterr().out
+        assert "A[B" in out
+
+    def test_render_empty(self, capsys):
+        _render_unresolved([])
+        out = capsys.readouterr().out
+        assert "All venues resolved" in out

--- a/tests/unit/cli/commands/test_metadata.py
+++ b/tests/unit/cli/commands/test_metadata.py
@@ -118,6 +118,79 @@ class TestMetadataUnresolved:
 
 
 @pytest.mark.unit
+class TestMetadataApplyOverrides:
+    """`metadata apply-overrides` refresh subcommand (Story 3.3)."""
+
+    def _patch_settings(self, path: str = "venue_overrides.csv"):
+        settings = MagicMock()
+        settings.firstrate.firstrate_venue_overrides_path = path
+        return patch("src.cli.commands.metadata.get_settings", return_value=settings)
+
+    def test_populated_merges_and_prints_summary(self, runner):
+        from src.services.metadata.venue_overrides import VenueOverrideMergeResult
+
+        session_patch, repo_patch = _patch_session_and_repo()
+        with (
+            self._patch_settings(),
+            patch(
+                "src.cli.commands.metadata.load_venue_overrides",
+                return_value={"SPY": "ARCA"},
+            ),
+            patch(
+                "src.cli.commands.metadata.merge_venue_overrides",
+                return_value=VenueOverrideMergeResult(applied=1, unchanged=0, unmatched=["ZZZ"]),
+            ),
+            session_patch,
+            repo_patch,
+        ):
+            result = runner.invoke(metadata, ["apply-overrides"])
+
+        assert result.exit_code == 0
+        assert "1 applied" in result.output
+        assert "ZZZ" in result.output  # unmatched surfaced
+
+    def test_empty_file_is_noop(self, runner):
+        with (
+            self._patch_settings(),
+            patch("src.cli.commands.metadata.load_venue_overrides", return_value={}),
+        ):
+            result = runner.invoke(metadata, ["apply-overrides"])
+
+        assert result.exit_code == 0
+        assert "No venue overrides to apply" in result.output
+
+    def test_malformed_file_degrades_gracefully(self, runner):
+        from src.services.metadata.venue_overrides import VenueOverrideError
+
+        with (
+            self._patch_settings(),
+            patch(
+                "src.cli.commands.metadata.load_venue_overrides",
+                side_effect=VenueOverrideError("header must be exactly 'ticker,venue'"),
+            ),
+        ):
+            result = runner.invoke(metadata, ["apply-overrides"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert "not applied" in result.output
+
+    def test_db_unconfigured_degrades_gracefully(self, runner):
+        ctx = MagicMock()
+        ctx.__enter__.side_effect = RuntimeError("Database not configured")
+        with (
+            self._patch_settings(),
+            patch("src.cli.commands.metadata.load_venue_overrides", return_value={"SPY": "ARCA"}),
+            patch("src.cli.commands.metadata.get_sync_session", return_value=ctx),
+        ):
+            result = runner.invoke(metadata, ["apply-overrides"])
+
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert "Metadata DB not available" in result.output
+
+
+@pytest.mark.unit
 class TestRegistration:
     """The `metadata` group is wired into the top-level CLI."""
 
@@ -126,6 +199,7 @@ class TestRegistration:
 
         assert "metadata" in cli.commands
         assert "unresolved" in cli.commands["metadata"].commands
+        assert "apply-overrides" in cli.commands["metadata"].commands
 
 
 @pytest.mark.unit

--- a/tests/unit/services/firstrate/test_import_service.py
+++ b/tests/unit/services/firstrate/test_import_service.py
@@ -1288,6 +1288,203 @@ class TestResolvedMetadataCollection:
         assert service.resolved_metadata == []
 
 
+# ---------------------------------------------------------------------------
+# Story 3.1: Venue qualification (nautilus_id from resolved venue + ADR-3 sync)
+# ---------------------------------------------------------------------------
+
+
+def _unresolved_metadata(ticker: str):
+    """Build a VENUE_UNRESOLVED domain InstrumentMetadata (venue None)."""
+    from src.models.instrument_metadata import (
+        InstrumentMetadata,
+        ResolutionStatus,
+    )
+
+    return InstrumentMetadata(
+        ticker=ticker,
+        metadata_provider="FAKE",
+        venue=None,
+        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
+    )
+
+
+@pytest.mark.unit
+class TestVenueQualification:
+    """Story 3.1: identity qualified from the resolved venue, ADR-3 sync."""
+
+    def _service_with_resolver(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+    ):
+        return ImportService(
+            catalog_manager=mock_catalog_manager,
+            metadata_service=mock_metadata_service,
+            instrument_mapper=mock_instrument_mapper,
+            metadata_resolver=resolver,
+        )
+
+    def test_qualify_ticker_uses_resolved_venue(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
+    ):
+        """A resolved venue drives sync_qualification; resolve_instrument_id unused (AC1/AC2)."""
+        resolver = MagicMock()
+        resolver.resolve.return_value = _domain_metadata("SPY")  # venue "ARCA"
+        qualified = InstrumentId.from_str("SPY.ARCA")
+        mock_instrument_mapper.sync_qualification.return_value = qualified
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        svc._resolve_metadata("SPY")
+        result = svc._qualify_ticker("SPY", CATALOG_NAME)
+
+        assert result == qualified
+        mock_instrument_mapper.sync_qualification.assert_called_once_with(
+            "SPY", CATALOG_NAME, "ARCA"
+        )
+        mock_instrument_mapper.resolve_instrument_id.assert_not_called()
+
+    def test_qualify_ticker_unresolved_returns_none(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
+    ):
+        """VENUE_UNRESOLVED venue → sync returns None → ticker left unqualified (AC3)."""
+        resolver = MagicMock()
+        resolver.resolve.return_value = _unresolved_metadata("ZZZ")
+        mock_instrument_mapper.sync_qualification.return_value = None
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        svc._resolve_metadata("ZZZ")
+        result = svc._qualify_ticker("ZZZ", CATALOG_NAME)
+
+        assert result is None
+        mock_instrument_mapper.sync_qualification.assert_called_once_with("ZZZ", CATALOG_NAME, None)
+
+    def test_qualify_ticker_no_resolver_falls_back_to_db_lookup(
+        self, service, mock_instrument_mapper
+    ):
+        """No resolver (stocks/unconfigured) → existing DB identity lookup, unchanged (AC4)."""
+        expected = InstrumentId.from_str("AAPL.XNAS")
+        mock_instrument_mapper.resolve_instrument_id.return_value = expected
+
+        result = service._qualify_ticker("AAPL", CATALOG_NAME)
+
+        assert result == expected
+        mock_instrument_mapper.resolve_instrument_id.assert_called_once_with("AAPL", CATALOG_NAME)
+        mock_instrument_mapper.sync_qualification.assert_not_called()
+
+    def test_qualify_ticker_resolver_fault_falls_back(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
+    ):
+        """A provider fault captures nothing → fall back to DB identity (fault-tolerant AC4)."""
+        resolver = MagicMock()
+        resolver.resolve.side_effect = RuntimeError("provider down")
+        expected = InstrumentId.from_str("SPY.ARCA")
+        mock_instrument_mapper.resolve_instrument_id.return_value = expected
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        svc._resolve_metadata("SPY")  # fault swallowed, nothing captured
+        result = svc._qualify_ticker("SPY", CATALOG_NAME)
+
+        assert result == expected
+        mock_instrument_mapper.sync_qualification.assert_not_called()
+
+    def test_unqualified_ticker_skips_bar_write(
+        self,
+        mock_catalog_manager,
+        mock_metadata_service,
+        mock_instrument_mapper,
+        mock_bars,
+        tmp_path,
+    ):
+        """End-to-end: an unresolved-venue ticker is skipped — no write_data, logged (AC3)."""
+        resolver = MagicMock()
+        resolver.resolve.return_value = _unresolved_metadata("ZZZ")
+        mock_instrument_mapper.sync_qualification.return_value = None
+        mock_metadata_service.get_instrument_sync.return_value = _fresh_instrument_row()
+
+        mock_catalog = MagicMock()
+        mock_catalog_manager.resolve_catalog.return_value = mock_catalog
+
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        (tmp_path / "Z").mkdir()
+        _write_daily_csv(tmp_path / "Z" / "ZZZ.txt", "2025-02-01")
+
+        with (
+            patch("src.services.firstrate.import_service.get_parser") as mock_get_parser,
+            patch("src.services.firstrate.import_service.logger") as mock_logger,
+        ):
+            mock_parser = MagicMock()
+            mock_parser.parse_file.return_value = mock_bars
+            mock_get_parser.return_value = mock_parser
+
+            results = svc.import_directory(
+                source_dir=tmp_path,
+                catalog_name=CATALOG_NAME,
+                asset_class=AssetClass.ETF,
+                timeframe="1-DAY-LAST",
+            )
+
+        assert len(results) == 1
+        assert results[0].status == "skipped"
+        assert results[0].outcome == "skipped"
+        # The skip carries a venue-unresolved reason so the progress line does
+        # not falsely report "already complete" (review EdgeCase #2).
+        assert results[0].error is not None
+        assert "venue unresolved" in results[0].error
+        mock_catalog.write_data.assert_not_called()
+        assert any(
+            call.args and call.args[0] == "ticker_unqualified"
+            for call in mock_logger.info.call_args_list
+        )
+
+    def test_qualification_synced_once_across_timeframes(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
+    ):
+        """Qualification runs at most once per ticker per run (review EdgeCase #3)."""
+        resolver = MagicMock()
+        resolver.resolve.return_value = _domain_metadata("SPY")
+        mock_instrument_mapper.sync_qualification.return_value = InstrumentId.from_str("SPY.ARCA")
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        svc._resolve_metadata("SPY")
+        first = svc._qualify_ticker("SPY", CATALOG_NAME)
+        second = svc._qualify_ticker("SPY", CATALOG_NAME)  # e.g. another timeframe pass
+
+        assert first == second == InstrumentId.from_str("SPY.ARCA")
+        assert mock_instrument_mapper.sync_qualification.call_count == 1  # deduped
+
+    def test_resolved_venue_missing_row_fails_loudly(
+        self, mock_catalog_manager, mock_metadata_service, mock_instrument_mapper
+    ):
+        """A resolved venue with no catalog_instruments row is NOT mislabeled unresolved.
+
+        Review Blind #1: sync returns None for a missing row too, so a resolved-
+        venue ticker absent from company_profiles must fall back to the loud DB
+        lookup, not be silently skipped as venue-unresolved.
+        """
+        from src.db.exceptions import InstrumentMappingError
+
+        resolver = MagicMock()
+        resolver.resolve.return_value = _domain_metadata("SPY")  # venue "ARCA"
+        mock_instrument_mapper.sync_qualification.return_value = None  # no row
+        mock_instrument_mapper.resolve_instrument_id.side_effect = InstrumentMappingError("no row")
+        svc = self._service_with_resolver(
+            mock_catalog_manager, mock_metadata_service, mock_instrument_mapper, resolver
+        )
+
+        svc._resolve_metadata("SPY")
+        with pytest.raises(InstrumentMappingError):
+            svc._qualify_ticker("SPY", CATALOG_NAME)
+
+
 @pytest.mark.unit
 class TestImportProgressLogging:
     """Story 2.7 AC1: per-ticker progress with running counts via structlog."""

--- a/tests/unit/services/firstrate/test_instrument_mapper.py
+++ b/tests/unit/services/firstrate/test_instrument_mapper.py
@@ -235,6 +235,78 @@ class TestResolveInstrumentId:
 
 
 # ---------------------------------------------------------------------------
+# Story 3.1: Venue qualification (nautilus_id from resolved venue + ADR-3 sync)
+# ---------------------------------------------------------------------------
+
+
+class TestQualification:
+    """Tests for qualified_instrument_id() and sync_qualification()."""
+
+    @pytest.mark.unit
+    def test_qualified_instrument_id_from_venue(self, mapper):
+        """A resolved venue yields a Nautilus-qualified InstrumentId."""
+        assert mapper.qualified_instrument_id("SPY", "ARCA") == InstrumentId.from_str("SPY.ARCA")
+
+    @pytest.mark.unit
+    def test_qualified_instrument_id_none_venue_returns_none(self, mapper):
+        """An unresolved (None) venue fabricates no identity (AC3)."""
+        assert mapper.qualified_instrument_id("SPY", None) is None
+
+    @pytest.mark.unit
+    def test_qualified_instrument_id_blank_venue_returns_none(self, mapper):
+        """A blank venue is treated as unresolved — no identity fabricated."""
+        assert mapper.qualified_instrument_id("SPY", "") is None
+
+    @pytest.mark.unit
+    def test_sync_qualification_writes_nautilus_id_and_exchange(self, mapper, mock_repo):
+        """Resolved venue overwrites the row's nautilus_id/exchange and upserts (ADR-3)."""
+        row = CatalogInstrument(
+            ticker="SPY",
+            nautilus_id="SPY.NYSE",  # provisional CSV exchange
+            exchange="NYSE",
+            asset_class="ETF",
+            catalog_name=CATALOG_NAME,
+        )
+        mock_repo.get_by_ticker.return_value = row
+
+        result = mapper.sync_qualification("SPY", CATALOG_NAME, "ARCA")
+
+        assert result == InstrumentId.from_str("SPY.ARCA")
+        assert row.nautilus_id == "SPY.ARCA"
+        assert row.exchange == "ARCA"
+        mock_repo.upsert.assert_called_once_with(row)
+
+    @pytest.mark.unit
+    def test_sync_qualification_unresolved_leaves_nautilus_id_none(self, mapper, mock_repo):
+        """A None venue leaves nautilus_id None (unqualified, not fabricated — AC3)."""
+        row = CatalogInstrument(
+            ticker="ZZZ",
+            nautilus_id="ZZZ.NYSE",
+            exchange="NYSE",
+            asset_class="ETF",
+            catalog_name=CATALOG_NAME,
+        )
+        mock_repo.get_by_ticker.return_value = row
+
+        result = mapper.sync_qualification("ZZZ", CATALOG_NAME, None)
+
+        assert result is None
+        assert row.nautilus_id is None
+        assert row.exchange is None
+        mock_repo.upsert.assert_called_once_with(row)
+
+    @pytest.mark.unit
+    def test_sync_qualification_missing_row_returns_none_no_upsert(self, mapper, mock_repo):
+        """No catalog_instruments row → defensive no-op (returns None, no upsert)."""
+        mock_repo.get_by_ticker.return_value = None
+
+        result = mapper.sync_qualification("SPY", CATALOG_NAME, "ARCA")
+
+        assert result is None
+        mock_repo.upsert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Task 2: is_loaded Tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/metadata/test_backtestable.py
+++ b/tests/unit/services/metadata/test_backtestable.py
@@ -1,0 +1,79 @@
+"""Unit tests for the pure backtestable classifier (Story 3.5)."""
+
+import dataclasses
+
+import pytest
+
+from src.db.models.catalog_instrument import CatalogInstrument
+from src.models.instrument_metadata import ResolutionStatus
+from src.services.metadata.backtestable import (
+    NonBacktestableTicker,
+    is_backtestable,
+    total_bars,
+)
+
+
+@pytest.mark.unit
+class TestIsBacktestable:
+    """`is_backtestable` keys strictly on the venue verdict."""
+
+    def test_resolved_is_backtestable(self):
+        assert is_backtestable(ResolutionStatus.RESOLVED) is True
+
+    def test_venue_unresolved_is_not_backtestable(self):
+        assert is_backtestable(ResolutionStatus.VENUE_UNRESOLVED) is False
+
+    def test_unresolved_is_not_backtestable(self):
+        assert is_backtestable(ResolutionStatus.UNRESOLVED) is False
+
+
+@pytest.mark.unit
+class TestTotalBars:
+    """`total_bars` sums the five per-timeframe bar counts (None → 0)."""
+
+    def test_sums_present_counts(self):
+        inst = CatalogInstrument(
+            ticker="SPY",
+            asset_class="ETF",
+            catalog_name="firstrate-etf",
+            bar_count_daily=2,
+            bar_count_minute=3,
+            bar_count_hourly=0,
+            bar_count_5min=0,
+            bar_count_30min=0,
+        )
+        assert total_bars(inst) == 5
+
+    def test_all_zero_returns_zero(self):
+        inst = CatalogInstrument(
+            ticker="SPY",
+            asset_class="ETF",
+            catalog_name="firstrate-etf",
+            bar_count_daily=0,
+            bar_count_minute=0,
+            bar_count_hourly=0,
+            bar_count_5min=0,
+            bar_count_30min=0,
+        )
+        assert total_bars(inst) == 0
+
+    def test_unset_counts_treated_as_zero(self):
+        # A freshly-constructed ORM object has None bar counts (defaults apply at INSERT).
+        inst = CatalogInstrument(ticker="SPY", asset_class="ETF", catalog_name="firstrate-etf")
+        assert total_bars(inst) == 0
+
+
+@pytest.mark.unit
+class TestNonBacktestableTicker:
+    """The flag record surfaced by the CLI."""
+
+    def test_bars_kept_true_when_retained(self):
+        assert NonBacktestableTicker("ZZZ", 10).bars_kept is True
+
+    def test_bars_kept_false_when_none_retained(self):
+        assert NonBacktestableTicker("QQQ", 0).bars_kept is False
+
+    def test_is_frozen(self):
+        ticker = NonBacktestableTicker("ZZZ", 10)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ticker.ticker = "AAA"  # type: ignore[misc]

--- a/tests/unit/services/metadata/test_coverage_report.py
+++ b/tests/unit/services/metadata/test_coverage_report.py
@@ -1,0 +1,64 @@
+"""Unit tests for the pure venue-coverage aggregate (Story 3.4)."""
+
+import pytest
+
+from src.models.instrument_metadata import ResolutionStatus
+from src.services.metadata.coverage_report import VenueCoverage
+
+
+@pytest.mark.unit
+class TestVenueCoverage:
+    """`VenueCoverage.from_counts` + coverage/gate math."""
+
+    def test_all_resolved_is_complete_100pct(self):
+        cov = VenueCoverage.from_counts({ResolutionStatus.RESOLVED: 10})
+        assert cov.resolved == 10
+        assert cov.venue_unresolved == 0
+        assert cov.decided == 10
+        assert cov.total == 10
+        assert cov.coverage_pct == 100.0
+        assert cov.is_complete is True
+
+    def test_mixed_with_unresolved_venue_fails_gate(self):
+        cov = VenueCoverage.from_counts(
+            {ResolutionStatus.RESOLVED: 8, ResolutionStatus.VENUE_UNRESOLVED: 2}
+        )
+        assert cov.venue_unresolved == 2
+        assert cov.decided == 10
+        assert cov.coverage_pct == 80.0
+        assert cov.is_complete is False
+
+    def test_never_attempted_excluded_from_pct_and_gate(self):
+        # UNRESOLVED = resolution not yet run: counted in total, out of the ratio,
+        # and NOT a gate blocker (only VENUE_UNRESOLVED fails the gate).
+        cov = VenueCoverage.from_counts(
+            {ResolutionStatus.RESOLVED: 5, ResolutionStatus.UNRESOLVED: 5}
+        )
+        assert cov.unresolved == 5
+        assert cov.total == 10
+        assert cov.decided == 5
+        assert cov.coverage_pct == 100.0
+        assert cov.is_complete is True
+
+    def test_empty_is_vacuously_complete(self):
+        cov = VenueCoverage.from_counts({})
+        assert cov.total == 0
+        assert cov.decided == 0
+        assert cov.coverage_pct == 100.0
+        assert cov.is_complete is True
+
+    def test_absent_statuses_default_to_zero(self):
+        cov = VenueCoverage.from_counts({ResolutionStatus.VENUE_UNRESOLVED: 3})
+        assert cov.resolved == 0
+        assert cov.unresolved == 0
+        assert cov.venue_unresolved == 3
+
+    def test_gate_identity_holds(self):
+        # is_complete  ⟺  coverage_pct == 100.0
+        complete = VenueCoverage.from_counts({ResolutionStatus.RESOLVED: 4})
+        assert complete.is_complete is True and complete.coverage_pct == 100.0
+
+        incomplete = VenueCoverage.from_counts(
+            {ResolutionStatus.RESOLVED: 4, ResolutionStatus.VENUE_UNRESOLVED: 1}
+        )
+        assert incomplete.is_complete is False and incomplete.coverage_pct < 100.0

--- a/tests/unit/services/metadata/test_unresolved_report.py
+++ b/tests/unit/services/metadata/test_unresolved_report.py
@@ -1,0 +1,65 @@
+"""Unit tests for the Story 3.2 unresolved-venue reason derivation."""
+
+import pytest
+
+from src.db.models.instrument_metadata import InstrumentMetadata
+from src.models.instrument_metadata import NA_SENTINEL, AssetType, ResolutionStatus
+from src.services.metadata.unresolved_report import unresolved_reason
+
+
+def _degraded_row(ticker: str = "ZZZ", provider: str = "FMP") -> InstrumentMetadata:
+    """An ORM row shaped like the FMP provider's `_degraded` output (unknown ticker)."""
+    return InstrumentMetadata(
+        ticker=ticker,
+        metadata_provider=provider,
+        venue=None,
+        currency=NA_SENTINEL,
+        asset_type=None,
+        company_name=NA_SENTINEL,
+        sector=NA_SENTINEL,
+        industry=NA_SENTINEL,
+        country=NA_SENTINEL,
+        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
+    )
+
+
+def _found_unmapped_row(ticker: str = "SPY", provider: str = "FMP") -> InstrumentMetadata:
+    """An ORM row shaped like `_to_domain` with a blank/ambiguous exchange label."""
+    return InstrumentMetadata(
+        ticker=ticker,
+        metadata_provider=provider,
+        venue=None,
+        currency="USD",
+        asset_type=AssetType.ETF.value,
+        company_name="SPDR S&P 500 ETF Trust",
+        sector=NA_SENTINEL,
+        industry=NA_SENTINEL,
+        country="US",
+        resolution_status=ResolutionStatus.VENUE_UNRESOLVED,
+    )
+
+
+@pytest.mark.unit
+class TestUnresolvedReason:
+    """Derive a human-readable reason for a VENUE_UNRESOLVED row."""
+
+    def test_degraded_row_is_unknown_to_provider(self):
+        reason = unresolved_reason(_degraded_row())
+        assert "unknown to FMP" in reason
+        assert "no profile" in reason.lower()
+
+    def test_found_but_unmapped_row_is_label_unusable(self):
+        reason = unresolved_reason(_found_unmapped_row())
+        assert "unknown to" not in reason.lower()
+        assert "ambiguous" in reason.lower()
+        assert "unmapped" in reason.lower()
+
+    def test_reason_is_provider_agnostic_degraded_branch(self):
+        reason = unresolved_reason(_degraded_row(provider="OTHER"))
+        assert "OTHER" in reason
+        assert "FMP" not in reason
+
+    def test_reason_is_provider_agnostic_found_branch(self):
+        reason = unresolved_reason(_found_unmapped_row(provider="OTHER"))
+        assert "OTHER" in reason
+        assert "FMP" not in reason

--- a/tests/unit/services/metadata/test_venue_overrides.py
+++ b/tests/unit/services/metadata/test_venue_overrides.py
@@ -1,0 +1,114 @@
+"""Unit tests for venue_overrides loader + merge core (Story 3.3)."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.metadata.venue_overrides import (
+    VenueOverrideError,
+    VenueOverrideMergeResult,
+    load_venue_overrides,
+    merge_venue_overrides,
+)
+
+
+def _write(path, text: str, encoding: str = "utf-8") -> None:
+    path.write_text(text, encoding=encoding)
+
+
+@pytest.mark.unit
+class TestLoadVenueOverrides:
+    """`load_venue_overrides` — pure CSV parse with normalization + skips."""
+
+    def test_valid_file_normalizes_ticker_and_venue(self, tmp_path):
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "ticker,venue\n spy , arca \nqqq,NASDAQ\n")
+        assert load_venue_overrides(f) == {"SPY": "ARCA", "QQQ": "NASDAQ"}
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_venue_overrides(tmp_path / "nope.csv") == {}
+
+    def test_header_only_returns_empty(self, tmp_path):
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "ticker,venue\n")
+        assert load_venue_overrides(f) == {}
+
+    def test_bom_header_is_tolerated(self, tmp_path):
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "ticker,venue\nSPY,ARCA\n", encoding="utf-8-sig")
+        assert load_venue_overrides(f) == {"SPY": "ARCA"}
+
+    def test_malformed_header_raises(self, tmp_path):
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "symbol,exchange\nSPY,ARCA\n")
+        with pytest.raises(VenueOverrideError):
+            load_venue_overrides(f)
+
+    def test_blank_ticker_venue_and_na_rows_skipped(self, tmp_path):
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "ticker,venue\n,ARCA\nSPY,\nQQQ,N/A\nIWM,BATS\n")
+        assert load_venue_overrides(f) == {"IWM": "BATS"}
+
+    def test_duplicate_ticker_last_wins(self, tmp_path):
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "ticker,venue\nSPY,NYSE\nSPY,ARCA\n")
+        assert load_venue_overrides(f) == {"SPY": "ARCA"}
+
+    def test_ragged_short_row_skipped(self, tmp_path):
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "ticker,venue\nSPY\nQQQ,NASDAQ\n")
+        assert load_venue_overrides(f) == {"QQQ": "NASDAQ"}
+
+    def test_empty_file_is_noop_not_error(self, tmp_path):
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "")
+        assert load_venue_overrides(f) == {}
+
+    def test_oversize_venue_skipped(self, tmp_path):
+        # Venue longer than the venue column (String(20)) is garbage — skip, don't
+        # push it to the DB where Postgres would DataError / SQLite silently truncate.
+        f = tmp_path / "venue_overrides.csv"
+        _write(f, "ticker,venue\nSPY," + "X" * 21 + "\nQQQ,ARCA\n")
+        assert load_venue_overrides(f) == {"QQQ": "ARCA"}
+
+    def test_non_utf8_file_degrades_to_override_error(self, tmp_path):
+        # Invalid bytes must surface as VenueOverrideError (caught by both callers),
+        # never a raw UnicodeDecodeError that aborts the import.
+        f = tmp_path / "venue_overrides.csv"
+        f.write_bytes(b"ticker,venue\nSPY,\xff\xfe\n")
+        with pytest.raises(VenueOverrideError):
+            load_venue_overrides(f)
+
+
+@pytest.mark.unit
+class TestMergeVenueOverrides:
+    """`merge_venue_overrides` — tallies repo outcomes, deterministic order."""
+
+    def test_tallies_applied_unchanged_unmatched(self):
+        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
+        repo = MagicMock()
+        outcomes = {"AAA": "applied", "BBB": "unchanged", "CCC": "unmatched"}
+        repo.apply_venue_override.side_effect = lambda t, v, r: outcomes[t]
+        result = merge_venue_overrides({"BBB": "NYSE", "AAA": "ARCA", "CCC": "IEX"}, repo, ts)
+        assert result.applied == 1
+        assert result.unchanged == 1
+        assert result.unmatched == ["CCC"]
+        assert result.total == 3
+
+    def test_processes_tickers_in_sorted_order_and_threads_clock(self):
+        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
+        repo = MagicMock()
+        repo.apply_venue_override.return_value = "applied"
+        merge_venue_overrides({"ZZZ": "ARCA", "AAA": "NYSE"}, repo, ts)
+        calls = repo.apply_venue_override.call_args_list
+        assert [c.args[0] for c in calls] == ["AAA", "ZZZ"]
+        # resolved_at threaded through unchanged (clock lives in the caller).
+        assert all(c.args[2] == ts for c in calls)
+
+    def test_empty_overrides_is_noop(self):
+        ts = datetime(2026, 7, 13, tzinfo=timezone.utc)
+        repo = MagicMock()
+        result = merge_venue_overrides({}, repo, ts)
+        assert result == VenueOverrideMergeResult()
+        repo.apply_venue_override.assert_not_called()

--- a/venue_overrides.csv
+++ b/venue_overrides.csv
@@ -1,0 +1,1 @@
+ticker,venue


### PR DESCRIPTION
## Automated BMAD run

Built end-to-end by the BMAD harness (PO-sim answered elicitation, verification gated on tests + acceptance-criteria traceability).

- Total model spend: $73.28
- Decisions made: 0 (0 escalated to human)

### Decision log (review the human-escalated ones first)

Traceability matrix attached as `traceability.json` in the run dir.